### PR TITLE
Add top-level API to set what clusters appear and in what order

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     name: CSL Test Suite Regressions
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v1
         with:
           submodules: recursive
       - name: Extract branch name

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,6 +204,7 @@ dependencies = [
  "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "test_utils 0.1.0",
+ "thiserror 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1690,6 +1691,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "thiserror-impl 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "thread_local"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2230,6 +2249,8 @@ dependencies = [
 "checksum tendril 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "707feda9f2582d5d680d733e38755547a3e8fb471e7ba11452ecfd9ce93a5d3b"
 "checksum termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+"checksum thiserror 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "cc6b305ec0e323c7b6cfff6098a22516e0063d0bb7c3d88660a890217dca099a"
+"checksum thiserror-impl 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45ba8d810d9c48fc456b7ad54574e8bfb7c7918a57ad7a6e6a0985d7959e8597"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum tinytemplate 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4574b75faccaacddb9b284faecdf0b544b80b6b294f3d062d325c5726a209c20"
 "checksum toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"

--- a/crates/citeproc/Cargo.toml
+++ b/crates/citeproc/Cargo.toml
@@ -32,6 +32,7 @@ csl = { path = "../csl" }
 citeproc-io = { path = "../io" }
 citeproc-proc = { path = "../proc" }
 citeproc-db = { path = "../db" }
+thiserror = "1.0.6"
 
 [dev-dependencies]
 test_utils = { path = "../test-utils" }

--- a/crates/citeproc/src/db/mod.rs
+++ b/crates/citeproc/src/db/mod.rs
@@ -377,8 +377,13 @@ impl Processor {
         id.lookup(self)
     }
 
-    pub fn get_cluster(&self, cluster_id: ClusterId) -> Arc<MarkupOutput> {
-        self.built_cluster(cluster_id)
+    /// Returns None if the cluster has not been assigned a position in the document.
+    pub fn get_cluster(&self, cluster_id: ClusterId) -> Option<Arc<MarkupOutput>> {
+        if self.cluster_note_number(cluster_id).is_some() {
+            Some(self.built_cluster(cluster_id))
+        } else {
+            None
+        }
     }
 
     pub fn get_bib_item(&self, ref_id: Atom) -> Arc<MarkupOutput> {

--- a/crates/citeproc/src/db/mod.rs
+++ b/crates/citeproc/src/db/mod.rs
@@ -489,11 +489,11 @@ impl Processor {
 }
 
 #[derive(Serialize, Deserialize)]
-pub struct DocumentPiece {
-    id: ClusterId,
+pub struct ClusterPosition {
+    pub id: ClusterId,
     /// If this is None, the piece is an in-text cluster. If it is Some, it is a note cluster.
     #[serde(skip_serializing_if = "Option::is_none")]
-    note: Option<u32>,
+    pub note: Option<u32>,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -526,7 +526,7 @@ impl Processor {
     /// them will all have the same first-reference-note-number if FRNN is used in later cites.
     ///
     /// May error without having set_cluster_ids, but with some set_cluster_note_number-s executed.
-    pub fn set_cluster_order(&mut self, pieces: &[DocumentPiece]) -> Result<(), ErrorKind> {
+    pub fn set_cluster_order(&mut self, pieces: &[ClusterPosition]) -> Result<(), ErrorKind> {
         let mut cluster_ids = Vec::with_capacity(pieces.len());
         let mut intext_number = 1u32;
         // (note number, next index)

--- a/crates/citeproc/src/db/mod.rs
+++ b/crates/citeproc/src/db/mod.rs
@@ -34,7 +34,7 @@ use csl::Style;
 use csl::StyleError;
 
 use citeproc_io::output::{markup::Markup, OutputFormat};
-use citeproc_io::{Cite, Cluster2, ClusterId, ClusterNumber, Reference};
+use citeproc_io::{Cite, Cluster, ClusterId, ClusterNumber, Reference};
 use csl::Atom;
 
 #[allow(dead_code)]
@@ -314,7 +314,7 @@ impl Processor {
         self.set_references(vec![refr])
     }
 
-    pub fn init_clusters(&mut self, clusters: Vec<Cluster2<Markup>>) {
+    pub fn init_clusters(&mut self, clusters: Vec<Cluster<Markup>>) {
         let mut cluster_ids = Vec::new();
         for cluster in clusters {
             let (cluster_id, number, cites) = cluster.split();
@@ -345,7 +345,7 @@ impl Processor {
         self.set_cluster_ids(Arc::new(cluster_ids));
     }
 
-    pub fn insert_cluster(&mut self, cluster: Cluster2<Markup>) {
+    pub fn insert_cluster(&mut self, cluster: Cluster<Markup>) {
         let (cluster_id, number, cites) = cluster.split();
         let cluster_ids = self.cluster_ids();
         if !cluster_ids.contains(&cluster_id) {

--- a/crates/citeproc/src/db/mod.rs
+++ b/crates/citeproc/src/db/mod.rs
@@ -498,7 +498,7 @@ pub struct DocumentPiece {
 
 #[derive(Debug, thiserror::Error)]
 pub enum ErrorKind {
-    #[error("set_complete_document called with a note number {0} that was out of order (e.g. [1, 2, 3, 1])")]
+    #[error("set_cluster_order called with a note number {0} that was out of order (e.g. [1, 2, 3, 1])")]
     NonMonotonicNoteNumber(u32),
 }
 
@@ -526,7 +526,7 @@ impl Processor {
     /// them will all have the same first-reference-note-number if FRNN is used in later cites.
     ///
     /// May error without having set_cluster_ids, but with some set_cluster_note_number-s executed.
-    pub fn set_complete_document(&mut self, pieces: &[DocumentPiece]) -> Result<(), ErrorKind> {
+    pub fn set_cluster_order(&mut self, pieces: &[DocumentPiece]) -> Result<(), ErrorKind> {
         let mut cluster_ids = Vec::with_capacity(pieces.len());
         let mut intext_number = 1u32;
         // (note number, next index)

--- a/crates/citeproc/src/db/mod.rs
+++ b/crates/citeproc/src/db/mod.rs
@@ -239,7 +239,7 @@ impl Processor {
                     snap.0.ir_gen2_add_given_name(cite_id);
                 });
             self.year_suffixes();
-            cluster
+            clusters
                 .par_iter()
                 .for_each_with(self.snap(), |snap, cluster| {
                     snap.0.built_cluster(cluster.id);

--- a/crates/citeproc/src/db/test.rs
+++ b/crates/citeproc/src/db/test.rs
@@ -20,12 +20,12 @@ mod position {
     fn cite_positions_ibid() {
         let mut db = Processor::test_db();
         db.init_clusters(vec![
-            Cluster2::Note {
+            Cluster::Note {
                 id: 1,
                 note: IntraNote::Single(1),
                 cites: vec![Cite::basic("one")],
             },
-            Cluster2::Note {
+            Cluster::Note {
                 id: 2,
                 note: IntraNote::Single(2),
                 cites: vec![Cite::basic("one")],
@@ -42,17 +42,17 @@ mod position {
     fn cite_positions_near_note() {
         let mut db = Processor::test_db();
         db.init_clusters(vec![
-            Cluster2::Note {
+            Cluster::Note {
                 id: 1,
                 note: IntraNote::Single(1),
                 cites: vec![Cite::basic("one")],
             },
-            Cluster2::Note {
+            Cluster::Note {
                 id: 2,
                 note: IntraNote::Single(2),
                 cites: vec![Cite::basic("other")],
             },
-            Cluster2::Note {
+            Cluster::Note {
                 id: 3,
                 note: IntraNote::Single(3),
                 cites: vec![Cite::basic("one")],

--- a/crates/citeproc/src/lib.rs
+++ b/crates/citeproc/src/lib.rs
@@ -11,11 +11,11 @@ extern crate serde_derive;
 
 pub(crate) mod db;
 pub use self::db::update::{DocUpdate, UpdateSummary};
-pub use self::db::{Processor, DocumentPiece, ErrorKind};
+pub use self::db::{Processor, ClusterPosition, ErrorKind};
 
 pub mod prelude {
     pub use crate::db::update::{DocUpdate, UpdateSummary};
-    pub use crate::db::{Processor, SupportedFormat};
+    pub use crate::db::{Processor, SupportedFormat, ClusterPosition};
     pub use citeproc_db::{
         CiteDatabase, CiteId, LocaleDatabase, LocaleFetchError, LocaleFetcher, StyleDatabase,
     };

--- a/crates/citeproc/src/lib.rs
+++ b/crates/citeproc/src/lib.rs
@@ -20,7 +20,7 @@ pub mod prelude {
         CiteDatabase, CiteId, LocaleDatabase, LocaleFetchError, LocaleFetcher, StyleDatabase,
     };
     pub use citeproc_io::output::{markup::Markup, OutputFormat};
-    pub use citeproc_io::{Cite, Cluster2, ClusterId, ClusterNumber, IntraNote, Reference};
+    pub use citeproc_io::{Cite, Cluster, ClusterId, ClusterNumber, IntraNote, Reference};
     pub use citeproc_proc::db::{HasFormatter, IrDatabase};
     pub use csl::Atom;
 }

--- a/crates/citeproc/src/lib.rs
+++ b/crates/citeproc/src/lib.rs
@@ -11,7 +11,7 @@ extern crate serde_derive;
 
 pub(crate) mod db;
 pub use self::db::update::{DocUpdate, UpdateSummary};
-pub use self::db::Processor;
+pub use self::db::{Processor, DocumentPiece, ErrorKind};
 
 pub mod prelude {
     pub use crate::db::update::{DocUpdate, UpdateSummary};

--- a/crates/io/src/cite.rs
+++ b/crates/io/src/cite.rs
@@ -246,38 +246,15 @@ impl PartialOrd for ClusterNumber {
 /// Similarly, it is up to a library consumer to make sure no clusters have the same number as any
 /// other.
 #[derive(Debug, Clone, Deserialize, PartialEq)]
-#[serde(untagged, bound(deserialize = ""))]
-pub enum Cluster<O: OutputFormat> {
-    Note {
-        note: IntraNote,
-        id: ClusterId,
-        cites: Vec<Cite<O>>,
-    },
-    InText {
-        #[serde(rename = "inText")]
-        in_text: u32,
-        id: ClusterId,
-        cites: Vec<Cite<O>>,
-    },
+#[serde(bound(deserialize = ""))]
+pub struct Cluster<O: OutputFormat> {
+    pub id: ClusterId,
+    pub cites: Vec<Cite<O>>,
 }
 
 impl<O: OutputFormat> Cluster<O> {
     pub fn id(&self) -> ClusterId {
-        match self {
-            Cluster::InText { id, .. } | Cluster::Note { id, .. } => *id,
-        }
-    }
-    pub fn cluster_number(&self) -> ClusterNumber {
-        match self {
-            Cluster::InText { in_text, .. } => ClusterNumber::InText(*in_text),
-            Cluster::Note { note, .. } => ClusterNumber::Note(*note),
-        }
-    }
-    pub fn split(self) -> (ClusterId, ClusterNumber, Vec<Cite<O>>) {
-        match self {
-            Cluster::Note { id, note, cites } => (id, ClusterNumber::Note(note), cites),
-            Cluster::InText { id, in_text, cites } => (id, ClusterNumber::InText(in_text), cites),
-        }
+        self.id
     }
 }
 

--- a/crates/io/src/cite.rs
+++ b/crates/io/src/cite.rs
@@ -247,7 +247,7 @@ impl PartialOrd for ClusterNumber {
 /// other.
 #[derive(Debug, Clone, Deserialize, PartialEq)]
 #[serde(untagged, bound(deserialize = ""))]
-pub enum Cluster2<O: OutputFormat> {
+pub enum Cluster<O: OutputFormat> {
     Note {
         note: IntraNote,
         id: ClusterId,
@@ -261,22 +261,22 @@ pub enum Cluster2<O: OutputFormat> {
     },
 }
 
-impl<O: OutputFormat> Cluster2<O> {
+impl<O: OutputFormat> Cluster<O> {
     pub fn id(&self) -> ClusterId {
         match self {
-            Cluster2::InText { id, .. } | Cluster2::Note { id, .. } => *id,
+            Cluster::InText { id, .. } | Cluster::Note { id, .. } => *id,
         }
     }
     pub fn cluster_number(&self) -> ClusterNumber {
         match self {
-            Cluster2::InText { in_text, .. } => ClusterNumber::InText(*in_text),
-            Cluster2::Note { note, .. } => ClusterNumber::Note(*note),
+            Cluster::InText { in_text, .. } => ClusterNumber::InText(*in_text),
+            Cluster::Note { note, .. } => ClusterNumber::Note(*note),
         }
     }
     pub fn split(self) -> (ClusterId, ClusterNumber, Vec<Cite<O>>) {
         match self {
-            Cluster2::Note { id, note, cites } => (id, ClusterNumber::Note(note), cites),
-            Cluster2::InText { id, in_text, cites } => (id, ClusterNumber::InText(in_text), cites),
+            Cluster::Note { id, note, cites } => (id, ClusterNumber::Note(note), cites),
+            Cluster::InText { id, in_text, cites } => (id, ClusterNumber::InText(in_text), cites),
         }
     }
 }
@@ -284,31 +284,31 @@ impl<O: OutputFormat> Cluster2<O> {
 #[test]
 fn json_clusters() {
     use crate::output::markup::Markup;
-    let c: Cluster2<Markup> =
+    let c: Cluster<Markup> =
         serde_json::from_str(r#"{ "note": 32, "id": 5, "cites": [] }"#).unwrap();
     assert_eq!(
         c,
-        Cluster2::Note {
+        Cluster::Note {
             note: IntraNote::Single(32),
             id: 5,
             cites: vec![]
         }
     );
-    let c2: Cluster2<Markup> =
+    let c2: Cluster<Markup> =
         serde_json::from_str(r#"{ "note": [8, 2], "id": 5, "cites": [] }"#).unwrap();
     assert_eq!(
         c2,
-        Cluster2::Note {
+        Cluster::Note {
             note: IntraNote::Multi(8, 2),
             id: 5,
             cites: vec![]
         }
     );
-    let c3: Cluster2<Markup> =
+    let c3: Cluster<Markup> =
         serde_json::from_str(r#"{ "inText": 32, "id": 5, "cites": [] }"#).unwrap();
     assert_eq!(
         c3,
-        Cluster2::InText {
+        Cluster::InText {
             in_text: 32,
             id: 5,
             cites: vec![]

--- a/crates/proc/src/disamb/test.rs
+++ b/crates/proc/src/disamb/test.rs
@@ -148,10 +148,10 @@ fn test() {
     let dfa2 = create_dfa::<Markup, MockProcessor>(db, &refr2);
     println!("{}", dfa2.debug_graph(db));
 
-    use citeproc_io::{Cite, Cluster2, IntraNote};
+    use citeproc_io::{Cite, Cluster, IntraNote};
 
     db.set_references(vec![refr, refr2]);
-    let cluster = Cluster2::Note {
+    let cluster = Cluster::Note {
         id: 1,
         note: IntraNote::Single(1),
         cites: vec![Cite::basic("ref_id")],

--- a/crates/proc/src/test.rs
+++ b/crates/proc/src/test.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
 use citeproc_db::{LocaleFetcher, PredefinedLocales, StyleDatabase};
-use citeproc_io::{output::markup::Markup, Cite, Cluster2, IntraNote, Reference};
+use citeproc_io::{output::markup::Markup, Cite, Cluster, IntraNote, Reference};
 use csl::Atom;
 
 use csl::Style;
@@ -86,7 +86,7 @@ impl MockProcessor {
         self.set_style_with_durability(Arc::new(style), Durability::MEDIUM);
     }
 
-    pub fn init_clusters(&mut self, clusters: Vec<Cluster2<Markup>>) {
+    pub fn init_clusters(&mut self, clusters: Vec<Cluster<Markup>>) {
         let mut cluster_ids = Vec::new();
         for cluster in clusters {
             let (cluster_id, number, cites) = cluster.split();

--- a/crates/proc/src/test.rs
+++ b/crates/proc/src/test.rs
@@ -89,14 +89,14 @@ impl MockProcessor {
     pub fn init_clusters(&mut self, clusters: Vec<Cluster<Markup>>) {
         let mut cluster_ids = Vec::new();
         for cluster in clusters {
-            let (cluster_id, number, cites) = cluster.split();
+            let Cluster { id: cluster_id, cites } = cluster;
             let mut ids = Vec::new();
-            for (index, cite) in cites.iter().enumerate() {
-                let cite_id = self.cite(cluster_id, index as u32, Arc::new(cite.clone()));
+            for (index, cite) in cites.into_iter().enumerate() {
+                let cite_id = self.cite(cluster_id, index as u32, Arc::new(cite));
                 ids.push(cite_id);
             }
             self.set_cluster_cites(cluster_id, Arc::new(ids));
-            self.set_cluster_note_number(cluster_id, number);
+            self.set_cluster_note_number(cluster_id, None);
             cluster_ids.push(cluster_id);
         }
         self.set_cluster_ids(Arc::new(cluster_ids));

--- a/crates/test-utils/src/humans.rs
+++ b/crates/test-utils/src/humans.rs
@@ -39,9 +39,8 @@ impl CitationItem {
             CitationItem::Map { cites } => cites,
         };
         let cites = v.iter().map(CiteprocJsCite::to_cite).collect();
-        Cluster::Note {
+        Cluster {
             id: index,
-            note: IntraNote::Single(index),
             cites,
         }
     }
@@ -294,16 +293,17 @@ impl JsExecutor<'_> {
                 continue;
             }
             let &note = self.current_note_numbers.get(&id).unwrap();
-            let text = (*self.proc.get_cluster(id)).clone();
-            results.push(CiteResult {
-                kind: ResultKind::Dots,
-                id,
-                note,
-                text: text
-                    .replace("&#x2f;", "/")
-                    // citeproc-js uses the #38 version
-                    .replace("&amp;", "&#38;"),
-            })
+            if let Some(text) = self.proc.get_cluster(id) {
+                results.push(CiteResult {
+                    kind: ResultKind::Dots,
+                    id,
+                    note,
+                    text: text
+                        .replace("&#x2f;", "/")
+                        // citeproc-js uses the #38 version
+                        .replace("&amp;", "&#38;"),
+                })
+            }
         }
         results.sort_by_key(|x| x.note);
         Results(results)
@@ -339,16 +339,10 @@ impl JsExecutor<'_> {
         }
 
         let mut renum = Vec::new();
-        let n_sub = pre.iter().filter(|PrePost(_st, n)| *n == note).count() as u32;
         self.to_renumbering(&mut renum, pre);
         self.to_renumbering(&mut renum, &[PrePost(cluster.cluster_id.clone(), note)]);
         self.to_renumbering(&mut renum, post);
-        let cluster = Cluster::Note {
-            id,
-            note: IntraNote::Multi(note, n_sub),
-            cites,
-        };
-        self.proc.insert_cluster(cluster);
+        self.proc.insert_cluster(Cluster { id, cites });
         self.proc.renumber_clusters(&renum);
         for (i, nn) in renum {
             self.current_note_numbers.insert(i, nn);

--- a/crates/test-utils/src/humans.rs
+++ b/crates/test-utils/src/humans.rs
@@ -8,7 +8,7 @@ use super::{Format, Mode, TestCase};
 
 use citeproc::prelude::*;
 use citeproc_io::{
-    Cite, Cluster2, ClusterId, ClusterNumber, IntraNote, Locators, Reference, Suppression,
+    Cite, Cluster, ClusterId, ClusterNumber, IntraNote, Locators, Reference, Suppression,
 };
 
 use lazy_static::lazy_static;
@@ -33,13 +33,13 @@ pub enum CitationItem {
 }
 
 impl CitationItem {
-    pub fn to_note_cluster(self, index: u32) -> Cluster2<Markup> {
+    pub fn to_note_cluster(self, index: u32) -> Cluster<Markup> {
         let v = match self {
             CitationItem::Array(v) => v,
             CitationItem::Map { cites } => cites,
         };
         let cites = v.iter().map(CiteprocJsCite::to_cite).collect();
-        Cluster2::Note {
+        Cluster::Note {
             id: index,
             note: IntraNote::Single(index),
             cites,
@@ -343,7 +343,7 @@ impl JsExecutor<'_> {
         self.to_renumbering(&mut renum, pre);
         self.to_renumbering(&mut renum, &[PrePost(cluster.cluster_id.clone(), note)]);
         self.to_renumbering(&mut renum, post);
-        let cluster = Cluster2::Note {
+        let cluster = Cluster::Note {
             id,
             note: IntraNote::Multi(note, n_sub),
             cites,

--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -114,7 +114,15 @@ impl TestCase {
 
             proc.set_references(self.input.clone());
             proc.init_clusters(clusters.clone());
-            proc.set_cluster_order(&[ClusterPosition { id: 1, note: Some(1) }]).unwrap();
+            let positions: Vec<_> = clusters
+                .iter()
+                .enumerate()
+                .map(|(ix, cluster)| {
+                    ClusterPosition { id: cluster.id, note: Some(ix as u32 + 1) }
+                })
+                .collect();
+
+            proc.set_cluster_order(&positions).unwrap();
             let mut pushed = false;
             for cluster in clusters.iter() {
                 if let Some(html) = proc.get_cluster(cluster.id()) {

--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -8,7 +8,7 @@
 extern crate serde_derive;
 
 use citeproc::prelude::*;
-use citeproc_io::{Cite, Cluster2, IntraNote, Reference};
+use citeproc_io::{Cite, Cluster, IntraNote, Reference};
 use csl::Lang;
 
 use directories::ProjectDirs;
@@ -105,7 +105,7 @@ impl TestCase {
                 for refr in self.input.iter() {
                     cites.push(Cite::basic(&refr.id));
                 }
-                clusters_auto.push(Cluster2::Note {
+                clusters_auto.push(Cluster::Note {
                     id: 1,
                     note: IntraNote::Single(1),
                     cites,

--- a/crates/test-utils/src/toml.rs
+++ b/crates/test-utils/src/toml.rs
@@ -6,7 +6,7 @@
 
 use citeproc::prelude::*;
 use citeproc_io::{
-    Cite, Cluster2, ClusterId, ClusterNumber, IntraNote, Locator, NumericValue, Reference,
+    Cite, Cluster, ClusterId, ClusterNumber, IntraNote, Locator, NumericValue, Reference,
     Suppression,
 };
 use csl::Lang;
@@ -72,7 +72,7 @@ use std::collections::HashMap;
 #[derive(Deserialize, Debug, PartialEq)]
 pub struct TomlInstruction {
     #[serde(default)]
-    clusters: Vec<Cluster2<Html>>,
+    clusters: Vec<Cluster<Html>>,
     #[serde(default)]
     refs: Vec<Reference>,
     #[serde(default)]

--- a/crates/wasm/js-demo/js/Document.ts
+++ b/crates/wasm/js-demo/js/Document.ts
@@ -137,7 +137,7 @@ export class Document {
         this.driver = driver;
         driver.initClusters(this.clusters);
         let pieces = this.clusters.map(c => ({ id: c.id, note: c.note }));
-        driver.setCompleteDocument(pieces);
+        driver.setClusterOrder(pieces);
         this.rendered = new RenderedDocument(this.clusters, driver);
         // Drain the update queue, because we know we're up to date
         this.driver.drain();
@@ -159,7 +159,7 @@ export class Document {
         return produce(this, draft => {
             fn(draft);
             let pieces = this.clusters.map(c => ({ id: c.id, note: c.note }));
-            driver.setCompleteDocument(pieces);
+            driver.setClusterOrder(pieces);
             let summary = driver.batchedUpdates();
             draft.rendered = draft.rendered.update(summary, this.ordered());
         });

--- a/crates/wasm/js-demo/js/Document.ts
+++ b/crates/wasm/js-demo/js/Document.ts
@@ -136,6 +136,8 @@ export class Document {
     private init(driver: Driver) {
         this.driver = driver;
         driver.initClusters(this.clusters);
+        let pieces = this.clusters.map(c => ({ id: c.id, note: c.note }));
+        driver.setCompleteDocument(pieces);
         this.rendered = new RenderedDocument(this.clusters, driver);
         // Drain the update queue, because we know we're up to date
         this.driver.drain();

--- a/crates/wasm/js-demo/js/Document.ts
+++ b/crates/wasm/js-demo/js/Document.ts
@@ -156,6 +156,8 @@ export class Document {
         let driver = this.driver;
         return produce(this, draft => {
             fn(draft);
+            let pieces = this.clusters.map(c => ({ id: c.id, note: c.note }));
+            driver.setCompleteDocument(pieces);
             let summary = driver.batchedUpdates();
             draft.rendered = draft.rendered.update(summary, this.ordered());
         });
@@ -221,17 +223,7 @@ export class Document {
             this.refCounts.increment(cluster);
             this.refCounts.decrement(atPos);
             this.clusters.splice(pos, 0, cluster);
-            let arr = [];
-            // cascade to the rest of it;
-            // modifies this.clusters at the same time as assembling an updater for the driver
-            // e.g. [2, 3, 3, 4, 4, 5, 5, 6, ...]
-            for (let i = pos + 1; i < this.clusters.length; i++) {
-                let cl = this.clusters[i];
-                cl.note = inc(cl.note);
-                arr.push([cl.id, { note: cl.note }]);
-            }
             this.driver.insertCluster(cluster);
-            this.driver.renumberClusters(arr)
         } else {
             if (this.clusters.length > 0) {
                 cluster.note = inc(this.clusters[this.clusters.length - 1].note);

--- a/crates/wasm/js-demo/js/Document.ts
+++ b/crates/wasm/js-demo/js/Document.ts
@@ -1,9 +1,8 @@
-import { Reference, Cite, Cluster, NoteCluster, Driver, UpdateSummary, Lifecycle } from '../../pkg';
+import { Reference, Cite, Cluster, ClusterPosition, Driver, UpdateSummary, Lifecycle } from '../../pkg';
 import { produce, immerable, Draft, IProduce } from 'immer';
 
 export type ClusterId = number;
 export type CiteId = number;
-export type OrderedClusterIds = Pick<NoteCluster, "id" | "note">;
 
 export class RenderedDocument {
 
@@ -13,21 +12,21 @@ export class RenderedDocument {
     public bibliographyIds: Array<string> = [];
     public bibliography: { [id: string]: string } = {};
 
-    public orderedClusterIds: Array<OrderedClusterIds> = [];
+    public orderedClusterIds: Array<ClusterPosition> = [];
 
     /** For showing a paint splash when clusters are updated */
     public updatedLastRevision: { [id: number]: boolean } = {};
 
-    constructor(clusters: NoteCluster[], driver: Driver) {
+    constructor(clusters: Cluster[], oci: Array<ClusterPosition>, driver: Driver) {
         this[immerable] = true;
+        this.orderedClusterIds = oci;
         for (let cluster of clusters) {
             this.builtClusters[cluster.id] = driver.builtCluster(cluster.id);
             // TODO: send note through a round trip and get it from builtCluster
-            this.orderedClusterIds.push({ id: cluster.id, note: cluster.note });
         }
     }
 
-    public update(summary: UpdateSummary, oci: Array<OrderedClusterIds>) {
+    public update(summary: UpdateSummary, oci: Array<ClusterPosition>) {
         let neu = produce(this, draft => {
             draft.updatedLastRevision = {};
             draft.orderedClusterIds = oci;
@@ -50,8 +49,6 @@ export class RenderedDocument {
     }
 
 }
-
-type NonNumberedCluster = Omit<NoteCluster, "note">;
 
 class RefCounter {
     private citekeyRefcounts = new Map<string, number>();
@@ -97,7 +94,7 @@ export class Document {
     private driver: Driver;
 
     /** The internal document model */
-    public clusters: NoteCluster[];
+    public clusters: Cluster[];
 
     public rendered: RenderedDocument;
 
@@ -106,7 +103,7 @@ export class Document {
     private nextClusterId = 100;
     private nextCiteId = 100;
 
-    constructor(clusters: NoteCluster[], driver?: Driver) {
+    constructor(clusters: Cluster[], driver?: Driver) {
         this.refCounts = new RefCounter(
             key => {
                 // console.log("reference subscribed", key);
@@ -123,10 +120,6 @@ export class Document {
         }
     }
 
-    private ordered() {
-        return this.clusters.map(c => ({ id: c.id, note: c.note, }));
-    }
-
     private initCitekeys() {
         for (let cluster of this.clusters) {
             this.refCounts.increment(cluster);
@@ -136,9 +129,8 @@ export class Document {
     private init(driver: Driver) {
         this.driver = driver;
         driver.initClusters(this.clusters);
-        let pieces = this.clusters.map(c => ({ id: c.id, note: c.note }));
-        driver.setClusterOrder(pieces);
-        this.rendered = new RenderedDocument(this.clusters, driver);
+        driver.setClusterOrder(this.clusterPositions());
+        this.rendered = new RenderedDocument(this.clusters, this.clusterPositions(), driver);
         // Drain the update queue, because we know we're up to date
         this.driver.drain();
     }
@@ -158,25 +150,29 @@ export class Document {
         let driver = this.driver;
         return produce(this, draft => {
             fn(draft);
-            let pieces = this.clusters.map(c => ({ id: c.id, note: c.note }));
-            driver.setClusterOrder(pieces);
+            driver.setClusterOrder(draft.clusterPositions());
             let summary = driver.batchedUpdates();
-            draft.rendered = draft.rendered.update(summary, this.ordered());
+            draft.rendered = draft.rendered.update(summary, this.clusterPositions());
         });
     };
+
+    clusterPositions(): Array<ClusterPosition> {
+        // Simple but good for a demo: one note number per cluster.
+        return this.clusters.map((c, i) => ({ id: c.id, note: i + 1 }));
+    }
 
     //////////////
     // Clusters //
     //////////////
 
-    createCluster(cites: Cite[]): NonNumberedCluster {
+    createCluster(cites: Cite[]): Cluster {
         return {
             id: this.nextClusterId++,
             cites: cites,
         };
     }
 
-    replaceCluster(cluster: NoteCluster) {
+    replaceCluster(cluster: Cluster) {
         // Mutate
         let idx = this.clusters.findIndex(c => c.id === cluster.id);
         this.refCounts.increment(cluster);
@@ -216,22 +212,15 @@ export class Document {
      * @param _cluster      A createCluster() result.
      * @param beforeCluster The cluster ID to insert this before; `null` = at the end.
      */
-    insertCluster(_cluster: NonNumberedCluster, beforeCluster: ClusterId | null) {
-        let cluster = _cluster as NoteCluster;
+    insertCluster(cluster: Cluster, beforeCluster: ClusterId | null) {
         let pos = beforeCluster === null ? -1 : this.clusters.findIndex(c => c.id === beforeCluster);
         if (pos !== -1) {
             let atPos = this.clusters[pos];
-            cluster.note = atPos.note;
             this.refCounts.increment(cluster);
             this.refCounts.decrement(atPos);
             this.clusters.splice(pos, 0, cluster);
             this.driver.insertCluster(cluster);
         } else {
-            if (this.clusters.length > 0) {
-                cluster.note = inc(this.clusters[this.clusters.length - 1].note);
-            } else {
-                cluster.note = 1;
-            }
             this.clusters.push(cluster);
             this.driver.insertCluster(cluster);
         }

--- a/crates/wasm/js-demo/js/DocumentEditor.tsx
+++ b/crates/wasm/js-demo/js/DocumentEditor.tsx
@@ -1,6 +1,6 @@
 import { Document, RenderedDocument } from './Document';
 import React, { useState, useEffect, useCallback } from 'react';
-import { NoteCluster, Cite } from '../../pkg';
+import { Cluster, Cite } from '../../pkg';
 
 import './bibliography.css';
 
@@ -16,7 +16,7 @@ export const DocumentEditor = ({document, onChange}: { document: Document; onCha
         });
         onChange(neu);
     };
-    let editors = document.clusters.map((cluster: NoteCluster) => {
+    let editors = document.clusters.map((cluster: Cluster) => {
         return <div key={cluster.id}>
             <button style={btnStyle} onClick={() => insertCluster(cluster.id)} >+cluster</button>
             <ClusterEditor
@@ -57,7 +57,7 @@ const ClusterViewer = React.memo(({note, html, touched}: { note: number | [numbe
     return <p className={"footnote"} style={style} dangerouslySetInnerHTML={{ __html: note + ". " + html }}></p>
 });
 
-const ClusterEditor = ({cluster, updateCluster, removeCluster}: {cluster: NoteCluster, removeCluster: () => void, updateCluster: (cluster: NoteCluster) => void}) => {
+const ClusterEditor = ({cluster, updateCluster, removeCluster}: {cluster: Cluster, removeCluster: () => void, updateCluster: (cluster: Cluster) => void}) => {
     let [me, setMe] = useState(cluster);
     let editors = cluster.cites.map((cite: Cite, i) => {
         return <CiteEditor key={i} cite={cite} update={ c => {

--- a/crates/wasm/js-demo/js/useDocument.ts
+++ b/crates/wasm/js-demo/js/useDocument.ts
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect } from 'react';
 import { Result, Err, Ok, Option, Some, None } from 'safe-types';
-import { Driver, Reference, Cluster, Cite, Lifecycle, UpdateSummary, NoteCluster } from '../../pkg';
+import { Driver, Reference, Cluster, Cite, Lifecycle, UpdateSummary } from '../../pkg';
 import { ClusterId, Document, RenderedDocument } from './Document';
 import { Fetcher } from './Fetcher';
 
@@ -26,7 +26,7 @@ const fetcher = new Fetcher();
  * Again, you don't have to use React hooks/useState etc and the Rust-like `safe-types`.
  * An example that would work in an imperative app (e.g. without React's automatic updating) is below.
  */
-export const useDocument = (initialStyle: string, initialReferences: Reference[], initialClusters: NoteCluster[]) => {
+export const useDocument = (initialStyle: string, initialReferences: Reference[], initialClusters: Cluster[]) => {
     const [references, setReferences] = useState(initialReferences);
     const [document, setDocument] = useState(None() as Option<Document>);
     const [inFlight, setInFlight] = useState(false);

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -25,7 +25,7 @@ use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::{future_to_promise, JsFuture};
 
 use citeproc::prelude::*;
-use citeproc::{Processor, DocumentPiece};
+use citeproc::{Processor, ClusterPosition};
 use csl::Lang;
 
 #[wasm_bindgen]
@@ -226,7 +226,7 @@ impl Driver {
     /// May error without having set_cluster_ids, but with some set_cluster_note_number-s executed.
     #[wasm_bindgen(js_name = "setClusterOrder")]
     pub fn set_cluster_order(&mut self, pieces: Box<[JsValue]>) -> Result<(), JsValue> {
-        let pieces: Vec<DocumentPiece> = utils::read_js_array(pieces)?;
+        let pieces: Vec<ClusterPosition> = utils::read_js_array(pieces)?;
         let mut eng = self.engine.borrow_mut();
         eng.set_cluster_order(&pieces)
             .map_err(|e| ErrorPlaceholder::throw(&format!("{:?}", e)))?;
@@ -353,19 +353,16 @@ export type ClusterNumber = {
     inText: number
 };
 
-export type NoteCluster = {
+export type Cluster = {
     id: number;
     cites: Cite[];
-    note: number | [number, number]
 };
 
-export type InTextCluster = {
+export type ClusterPosition = {
     id: number;
-    cites: Cite[];
-    in_text: number;
-};
-
-export type Cluster = NoteCluster | InTextCluster;
+    /** Leaving off this field means this cluster is in-text. */
+    note?: number;
+}
 
 export type Reference = {
     id: string;

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -224,11 +224,11 @@ impl Driver {
     /// them will all have the same first-reference-note-number if FRNN is used in later cites.
     ///
     /// May error without having set_cluster_ids, but with some set_cluster_note_number-s executed.
-    #[wasm_bindgen(js_name = "setCompleteDocument")]
-    pub fn set_complete_document(&mut self, pieces: Box<[JsValue]>) -> Result<(), JsValue> {
+    #[wasm_bindgen(js_name = "setClusterOrder")]
+    pub fn set_cluster_order(&mut self, pieces: Box<[JsValue]>) -> Result<(), JsValue> {
         let pieces: Vec<DocumentPiece> = utils::read_js_array(pieces)?;
         let mut eng = self.engine.borrow_mut();
-        eng.set_complete_document(&pieces)
+        eng.set_cluster_order(&pieces)
             .map_err(|e| ErrorPlaceholder::throw(&format!("{:?}", e)))?;
         Ok(())
     }


### PR DESCRIPTION
CC @adomasven; Fixes #21, much more discussion there

It seems to work, although the js-demo does not test in-text numbering. Haven't swapped out the serialization strategy yet, but that's not really important. Two things remain:

The main thing is naming -- this is a very difficult method to name. Currently it's `setCompleteDocument`, which is cool except there is no such thing as a Document struct, so I'm unconvinced.

The second is what to do about the existing API (doesn't need to be resolved today). I wouldn't mind actually removing note/inText, and just having sort order technically-undefined-but-some-deterministic-choice until either renumberClusters/setCompleteDocument is called and that cluster gains a position.