### PR TITLE
Treat in-text and note clusters as different streams

### DIFF
--- a/crates/citeproc/src/db/mod.rs
+++ b/crates/citeproc/src/db/mod.rs
@@ -317,7 +317,10 @@ impl Processor {
     pub fn init_clusters(&mut self, clusters: Vec<Cluster<Markup>>) {
         let mut cluster_ids = Vec::new();
         for cluster in clusters {
-            let Cluster { id: cluster_id, cites } = cluster;
+            let Cluster {
+                id: cluster_id,
+                cites,
+            } = cluster;
             let mut ids = Vec::new();
             for (index, cite) in cites.into_iter().enumerate() {
                 let cite_id = self.cite(cluster_id, index as u32, Arc::new(cite));
@@ -346,7 +349,10 @@ impl Processor {
     }
 
     pub fn insert_cluster(&mut self, cluster: Cluster<Markup>) {
-        let Cluster { id: cluster_id, cites } = cluster;
+        let Cluster {
+            id: cluster_id,
+            cites,
+        } = cluster;
         let cluster_ids = self.cluster_ids();
         if !cluster_ids.contains(&cluster_id) {
             let mut new_cluster_ids = (*cluster_ids).clone();
@@ -498,7 +504,9 @@ pub struct ClusterPosition {
 
 #[derive(Debug, thiserror::Error)]
 pub enum ErrorKind {
-    #[error("set_cluster_order called with a note number {0} that was out of order (e.g. [1, 2, 3, 1])")]
+    #[error(
+        "set_cluster_order called with a note number {0} that was out of order (e.g. [1, 2, 3, 1])"
+    )]
     NonMonotonicNoteNumber(u32),
 }
 
@@ -541,15 +549,24 @@ impl Processor {
                         let (num, ref mut index) = *note;
                         let i = *index;
                         *index += 1;
-                        self.set_cluster_note_number(piece.id, Some(ClusterNumber::Note(IntraNote::Multi(num, i))));
+                        self.set_cluster_note_number(
+                            piece.id,
+                            Some(ClusterNumber::Note(IntraNote::Multi(num, i))),
+                        );
                     } else if nn > note.0 {
-                        self.set_cluster_note_number(piece.id, Some(ClusterNumber::Note(IntraNote::Multi(nn, 0))));
+                        self.set_cluster_note_number(
+                            piece.id,
+                            Some(ClusterNumber::Note(IntraNote::Multi(nn, 0))),
+                        );
                         *note = (nn, 1);
                     }
                 } else {
                     // the first note in the document
                     this_note = Some((nn, 1));
-                    self.set_cluster_note_number(piece.id, Some(ClusterNumber::Note(IntraNote::Multi(nn, 0))));
+                    self.set_cluster_note_number(
+                        piece.id,
+                        Some(ClusterNumber::Note(IntraNote::Multi(nn, 0))),
+                    );
                 }
                 cluster_ids.push(piece.id);
             } else {

--- a/crates/citeproc/src/lib.rs
+++ b/crates/citeproc/src/lib.rs
@@ -11,11 +11,11 @@ extern crate serde_derive;
 
 pub(crate) mod db;
 pub use self::db::update::{DocUpdate, UpdateSummary};
-pub use self::db::{Processor, ClusterPosition, ErrorKind};
+pub use self::db::{ClusterPosition, ErrorKind, Processor};
 
 pub mod prelude {
     pub use crate::db::update::{DocUpdate, UpdateSummary};
-    pub use crate::db::{Processor, SupportedFormat, ClusterPosition};
+    pub use crate::db::{ClusterPosition, Processor, SupportedFormat};
     pub use citeproc_db::{
         CiteDatabase, CiteId, LocaleDatabase, LocaleFetchError, LocaleFetcher, StyleDatabase,
     };

--- a/crates/io/src/output/markup.rs
+++ b/crates/io/src/output/markup.rs
@@ -278,7 +278,13 @@ pub trait MarkupWriter {
     }
 
     /// Use this to write an InlineElement::Formatted
-    fn stack_formats(&self, s: &mut String, inlines: &[InlineElement], formatting: Formatting, display: Option<DisplayMode>) {
+    fn stack_formats(
+        &self,
+        s: &mut String,
+        inlines: &[InlineElement],
+        formatting: Formatting,
+        display: Option<DisplayMode>,
+    ) {
         let stack = tag_stack(formatting, display);
         self.stack_preorder(s, &stack);
         for inner in inlines {

--- a/crates/io/src/output/markup/html.rs
+++ b/crates/io/src/output/markup/html.rs
@@ -116,12 +116,16 @@ impl FormatCmd {
             FormatCmd::FontVariantSmallCaps => ("span", r#" style="font-variant:small-caps;""#),
             FormatCmd::FontVariantNormal => ("span", r#" style="font-variant:normal;""#),
 
-            FormatCmd::TextDecorationUnderline => ("span", r#" style="text-decoration:underline;""#),
+            FormatCmd::TextDecorationUnderline => {
+                ("span", r#" style="text-decoration:underline;""#)
+            }
             FormatCmd::TextDecorationNone => ("span", r#" style="text-decoration:none;""#),
 
             FormatCmd::VerticalAlignmentSuperscript => ("sup", ""),
             FormatCmd::VerticalAlignmentSubscript => ("sub", ""),
-            FormatCmd::VerticalAlignmentBaseline => ("span", r#" style="vertical-alignment:baseline;"#),
+            FormatCmd::VerticalAlignmentBaseline => {
+                ("span", r#" style="vertical-alignment:baseline;"#)
+            }
         }
     }
 }

--- a/crates/proc/src/db.rs
+++ b/crates/proc/src/db.rs
@@ -548,7 +548,14 @@ fn disambiguate_add_names(
                 break;
             }
             if also_expand {
-                expand_one_name_ir(db, ir, ctx, &initial_refs, &mut nir_arc.lock().unwrap(), n as u32);
+                expand_one_name_ir(
+                    db,
+                    ir,
+                    ctx,
+                    &initial_refs,
+                    &mut nir_arc.lock().unwrap(),
+                    n as u32,
+                );
             }
             let new_count = total_ambiguity_number();
             nir_arc.lock().unwrap().achieved_count(new_count);

--- a/crates/proc/src/disamb/mod.rs
+++ b/crates/proc/src/disamb/mod.rs
@@ -287,12 +287,11 @@ pub fn create_ref_ir<O: OutputFormat, DB: IrDatabase>(
             // 0 = none of them enabled
             // 1 = first disambiguate="X" tests as true
             // count = all of the (reachable) checks test as true
-            (0..=count).into_iter()
-                .map(move |c| {
-                    let mut cloned = ctx.clone();
-                    cloned.disamb_count = c;
-                    (fc, cloned)
-                })
+            (0..=count).into_iter().map(move |c| {
+                let mut cloned = ctx.clone();
+                cloned.disamb_count = c;
+                (fc, cloned)
+            })
         })
         .map(|(fc, cloned)| {
             let mut state = IrState::new();

--- a/crates/proc/src/disamb/ref_context.rs
+++ b/crates/proc/src/disamb/ref_context.rs
@@ -194,7 +194,7 @@ where
     }
     fn is_disambiguate(&self, current_count: u32) -> bool {
         // See docs on is_disambiguate
-        // current_count is mutated as IR is rolled out; 
+        // current_count is mutated as IR is rolled out;
         // so for
         //    RefContext { disamb_count: 0 } => is_disambiguate is always false
         //    RefContext { disamb_count: 1 } => is_disambiguate is true for the first disambiguate="X" check only
@@ -235,7 +235,8 @@ impl<'a, O: OutputFormat> StyleWalker for DisambCounter<'a, O> {
         for branch in iter {
             // Run with a count of MAX so that eval_true means "true even without disambiguate set to
             // true", hence still works as a circuit-breaking "stop counting" mechanism.
-            let (eval_true, is_disambiguate) = crate::choose::eval_conditions(&branch.0, self.ctx, std::u32::MAX);
+            let (eval_true, is_disambiguate) =
+                crate::choose::eval_conditions(&branch.0, self.ctx, std::u32::MAX);
             if is_disambiguate {
                 sum += 1;
             }

--- a/crates/proc/src/helpers.rs
+++ b/crates/proc/src/helpers.rs
@@ -8,7 +8,7 @@ use crate::prelude::*;
 
 use citeproc_io::output::markup::Markup;
 use csl::Atom;
-use csl::{Affixes, Element, Formatting, DisplayMode};
+use csl::{Affixes, DisplayMode, Element, Formatting};
 
 pub fn sequence<'c, O, I>(
     db: &impl IrDatabase,
@@ -46,11 +46,7 @@ where
                 formatting,
                 affixes,
                 delimiter,
-                display: if ctx.in_bibliography {
-                    display
-                } else {
-                    None
-                },
+                display: if ctx.in_bibliography { display } else { None },
             }),
             gv,
         )
@@ -65,7 +61,7 @@ pub fn ref_sequence<'c>(
     delimiter: Atom,
     formatting: Option<Formatting>,
     affixes: Affixes,
-    display: Option<DisplayMode>
+    display: Option<DisplayMode>,
 ) -> (RefIR, GroupVars) {
     let _fmt = &ctx.format;
 

--- a/crates/proc/src/lib.rs
+++ b/crates/proc/src/lib.rs
@@ -45,7 +45,7 @@ pub(crate) mod prelude {
     pub use citeproc_io::output::OutputFormat;
     pub use citeproc_io::IngestOptions;
 
-    pub use csl::{Affixes, Element, Formatting, DisplayMode};
+    pub use csl::{Affixes, DisplayMode, Element, Formatting};
 
     pub use crate::cite_context::CiteContext;
     pub use crate::group::GroupVars;

--- a/crates/proc/src/sort.rs
+++ b/crates/proc/src/sort.rs
@@ -148,7 +148,9 @@ pub fn bib_ordering(
                 AnyVariable::Ordinary(v) => {
                     compare_demoting_none(a.ordinary.get(&v), b.ordinary.get(&v))
                 }
-                AnyVariable::Number(NumberVariable::CitationNumber) => compare_demoting_none(Some(a_cnum), Some(b_cnum)),
+                AnyVariable::Number(NumberVariable::CitationNumber) => {
+                    compare_demoting_none(Some(a_cnum), Some(b_cnum))
+                }
                 AnyVariable::Number(v) => compare_demoting_none(a.number.get(&v), b.number.get(&v)),
                 AnyVariable::Name(v) => {
                     let a_strings = crate::names::sort_strings_for_names(

--- a/crates/proc/src/test.rs
+++ b/crates/proc/src/test.rs
@@ -89,7 +89,10 @@ impl MockProcessor {
     pub fn init_clusters(&mut self, clusters: Vec<Cluster<Markup>>) {
         let mut cluster_ids = Vec::new();
         for cluster in clusters {
-            let Cluster { id: cluster_id, cites } = cluster;
+            let Cluster {
+                id: cluster_id,
+                cites,
+            } = cluster;
             let mut ids = Vec::new();
             for (index, cite) in cites.into_iter().enumerate() {
                 let cite_id = self.cite(cluster_id, index as u32, Arc::new(cite));

--- a/crates/proc/src/walker.rs
+++ b/crates/proc/src/walker.rs
@@ -33,7 +33,8 @@ pub trait StyleWalker {
     /// Default impl tries to use `self.get_checker()`, otherwise false.
     fn should_take_branch(&mut self, conditions: &Conditions) -> bool {
         if let Some(ck) = self.get_checker() {
-            let (eval_true, _is_disambiguate) = crate::choose::eval_conditions(conditions, ck, std::u32::MAX);
+            let (eval_true, _is_disambiguate) =
+                crate::choose::eval_conditions(conditions, ck, std::u32::MAX);
             eval_true
         } else {
             false

--- a/crates/test-utils/src/humans.rs
+++ b/crates/test-utils/src/humans.rs
@@ -39,10 +39,7 @@ impl CitationItem {
             CitationItem::Map { cites } => cites,
         };
         let cites = v.iter().map(CiteprocJsCite::to_cite).collect();
-        Cluster {
-            id: index,
-            cites,
-        }
+        Cluster { id: index, cites }
     }
 }
 

--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -105,10 +105,7 @@ impl TestCase {
                 for refr in self.input.iter() {
                     cites.push(Cite::basic(&refr.id));
                 }
-                clusters_auto.push(Cluster {
-                    id: 1,
-                    cites,
-                });
+                clusters_auto.push(Cluster { id: 1, cites });
                 &clusters_auto
             };
 
@@ -117,8 +114,9 @@ impl TestCase {
             let positions: Vec<_> = clusters
                 .iter()
                 .enumerate()
-                .map(|(ix, cluster)| {
-                    ClusterPosition { id: cluster.id, note: Some(ix as u32 + 1) }
+                .map(|(ix, cluster)| ClusterPosition {
+                    id: cluster.id,
+                    note: Some(ix as u32 + 1),
                 })
                 .collect();
 

--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -125,7 +125,7 @@ mod suity_ser {
         /// One specific instance of test
         Test,
         /// Group of tests
-        Suite
+        Suite,
     }
 
     #[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
@@ -465,18 +465,37 @@ impl std::str::FromStr for TestSuiteDiff {
     }
 }
 
-
 pub fn diff_tests(base_name: &str, current_name: &str) -> Result<(), Error> {
     let blessed = read_snapshot(base_name)?;
     let current = read_snapshot(current_name)?;
     let max_len = std::cmp::max(base_name.len(), current_name.len()).max("test result".len());
     let diff = current.diff(&blessed);
-    let b_pad: String = std::iter::repeat(' ').take(max_len - base_name.len()).collect();
-    let c_pad: String = std::iter::repeat(' ').take(max_len - current_name.len()).collect();
-    let r_pad: String = std::iter::repeat(' ').take(max_len - "test_result".len()).collect();
+    let b_pad: String = std::iter::repeat(' ')
+        .take(max_len - base_name.len())
+        .collect();
+    let c_pad: String = std::iter::repeat(' ')
+        .take(max_len - current_name.len())
+        .collect();
+    let r_pad: String = std::iter::repeat(' ')
+        .take(max_len - "test_result".len())
+        .collect();
     let should_fail = diff.print(r_pad);
-    println!("{}{}: {} passed; {} failed; {} ignored", b_pad, base_name, blessed.ok.len(), blessed.failed.len(), blessed.ignored.len());
-    println!("{}{}: {} passed; {} failed; {} ignored", c_pad, current_name, current.ok.len(), current.failed.len(), current.ignored.len());
+    println!(
+        "{}{}: {} passed; {} failed; {} ignored",
+        b_pad,
+        base_name,
+        blessed.ok.len(),
+        blessed.failed.len(),
+        blessed.ignored.len()
+    );
+    println!(
+        "{}{}: {} passed; {} failed; {} ignored",
+        c_pad,
+        current_name,
+        current.ok.len(),
+        current.failed.len(),
+        current.ignored.len()
+    );
     if should_fail {
         std::process::exit(1);
     }

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -14,10 +14,10 @@ extern crate log;
 
 use self::utils::ErrorPlaceholder;
 
-use std::error::Error;
 use js_sys::{Error as JsError, Promise};
 use serde::Serialize;
 use std::cell::RefCell;
+use std::error::Error;
 use std::rc::Rc;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -25,7 +25,7 @@ use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::{future_to_promise, JsFuture};
 
 use citeproc::prelude::*;
-use citeproc::{Processor, ClusterPosition};
+use citeproc::{ClusterPosition, Processor};
 use csl::Lang;
 
 #[wasm_bindgen]
@@ -157,10 +157,13 @@ impl Driver {
         let eng = self.engine.borrow();
         let built = eng.get_cluster(id);
         Ok(built
-            .ok_or_else(|| JsError::new(&format!("Cluster {} has not been assigned a position in the document.", id)))
-            .and_then(|b| {
-                JsValue::from_serde(&b).map_err(|e| JsError::new(e.description()))
-            })?)
+            .ok_or_else(|| {
+                JsError::new(&format!(
+                    "Cluster {} has not been assigned a position in the document.",
+                    id
+                ))
+            })
+            .and_then(|b| JsValue::from_serde(&b).map_err(|e| JsError::new(e.description())))?)
     }
 
     #[wasm_bindgen(js_name = "makeBibliography")]


### PR DESCRIPTION
Fixes #28

They probably shouldn't be *quite* this separate, however. The new set_cluster_order interface has more information than before, so you can turn this

> Some paragraph with a forced footnote.`[^1]` But then a normal in-text reference.[@citekey]
>
> `[^1]: @citekey`

into

```rust
db.set_cluster_order(&[
  ClusterPosition { id: 1, Some(1) }, // i.e. note 1
  ClusterPosition { id: 2, None },    // i.e. in-text reference
]);
```

Resulting in the in-text reference being after a footnote, and hence having `Position::Subsequent` and first-reference-note-number available. But currently that extra intermingling is thrown away.