### PR TITLE
Page ranges

### DIFF
--- a/crates/citeproc/tests/data/ignore.txt
+++ b/crates/citeproc/tests/data/ignore.txt
@@ -7,3 +7,5 @@ nameattr_EtAlSubsequentUseFirstOnCitationInCitation.txt
 nameattr_EtAlSubsequentUseFirstOnStyleInCitation.txt
 disambiguate_BasedOnSubsequentFormWithBackref.txt
 disambiguate_BasedOnSubsequentFormWithLocator.txt
+# uses a whole lot of citeproc-js options
+form_ShortTitleOnly.txt

--- a/crates/csl/src/lib.rs
+++ b/crates/csl/src/lib.rs
@@ -84,7 +84,7 @@ impl AttrChecker for Formatting {
             || attr == "font-variant"
             || attr == "font-weight"
             || attr == "text-decoration"
-            || attr == "vertical-alignment"
+            || attr == "vertical-align"
             || attr == "strip-periods"
     }
 }
@@ -146,7 +146,7 @@ impl FromNode for Formatting {
             font_variant: attribute_option(node, "font-variant", info)?,
             font_weight: attribute_option(node, "font-weight", info)?,
             text_decoration: attribute_option(node, "text-decoration", info)?,
-            vertical_alignment: attribute_option(node, "vertical-alignment", info)?,
+            vertical_alignment: attribute_option(node, "vertical-align", info)?,
             // TODO: carry options from root
             // hyperlink: String::from(""),
         })

--- a/crates/csl/src/locale.rs
+++ b/crates/csl/src/locale.rs
@@ -209,6 +209,10 @@ impl FromNode for TermEl {
                 SimpleTermSelector::Misc(t, TermFormExtended::from_node(node, info)?),
                 content,
             )),
+            Category(t) => Ok(TermEl::Simple(
+                SimpleTermSelector::Category(t, TermForm::from_node(node, info)?),
+                content,
+            )),
             Quote(t) => Ok(TermEl::Simple(SimpleTermSelector::Quote(t), content)),
             Role(t) => Ok(TermEl::Role(
                 RoleTermSelector(t, TermFormExtended::from_node(node, info)?),
@@ -284,6 +288,17 @@ impl Locale {
         let mut found = None;
         for sel in selector.fallback() {
             if let f @ Some(_) = self.gendered_terms.get(&sel) {
+                found = f;
+                break;
+            }
+        }
+        found
+    }
+
+    pub fn get_simple_term(&self, selector: SimpleTermSelector) -> Option<&TermPlurality> {
+        let mut found = None;
+        for sel in selector.fallback() {
+            if let f @ Some(_) = self.simple_terms.get(&sel) {
                 found = f;
                 break;
             }

--- a/crates/csl/src/style/mod.rs
+++ b/crates/csl/src/style/mod.rs
@@ -4,7 +4,7 @@
 //
 // Copyright © 2018 Corporation for Digital Scholarship
 
-use super::terms::{TermForm, TermFormExtended, TextTermSelector};
+use super::terms::{TermForm, TermFormExtended, TextTermSelector, Category};
 use super::IsIndependent;
 use crate::error::*;
 use crate::locale::{Lang, Locale};
@@ -1035,7 +1035,9 @@ impl Default for StyleClass {
 }
 
 #[derive(Default, Debug, Eq, Clone, PartialEq)]
-pub struct Info {}
+pub struct Info {
+    pub categories: Vec<Category>,
+}
 
 #[derive(Debug, Eq, Clone, PartialEq)]
 pub struct Style {

--- a/crates/csl/src/style/mod.rs
+++ b/crates/csl/src/style/mod.rs
@@ -1292,7 +1292,7 @@ impl Position {
 }
 
 /// [Spec](https://docs.citationstyles.org/en/stable/specification.html#appendix-v-page-range-formats)
-#[derive(AsRefStr, EnumProperty, EnumString, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(AsRefStr, EnumProperty, EnumString, Debug, Copy, Clone, PartialEq, Eq, Hash)]
 #[strum(serialize_all = "kebab_case")]
 pub enum PageRangeFormat {
     Chicago,

--- a/crates/csl/src/terms.rs
+++ b/crates/csl/src/terms.rs
@@ -26,6 +26,7 @@ pub enum AnyTermName {
     Loc(LocatorType),
 
     Misc(MiscTerm),
+    Category(Category),
     Season(SeasonTerm),
     Quote(QuoteTerm),
 
@@ -36,23 +37,24 @@ pub enum AnyTermName {
 
 impl GetAttribute for AnyTermName {
     fn get_attr(s: &str, features: &Features) -> Result<Self, UnknownAttributeValue> {
-        use self::AnyTermName::*;
         if let Ok(v) = MiscTerm::get_attr(s, features) {
-            return Ok(Misc(v));
+            return Ok(AnyTermName::Misc(v));
         } else if let Ok(v) = MonthTerm::get_attr(s, features) {
-            return Ok(Month(v));
+            return Ok(AnyTermName::Month(v));
         } else if let Ok(v) = NumberVariable::get_attr(s, features) {
-            return Ok(Number(v));
+            return Ok(AnyTermName::Number(v));
         } else if let Ok(v) = LocatorType::get_attr(s, features) {
-            return Ok(Loc(v));
+            return Ok(AnyTermName::Loc(v));
         } else if let Ok(v) = SeasonTerm::get_attr(s, features) {
-            return Ok(Season(v));
+            return Ok(AnyTermName::Season(v));
         } else if let Ok(v) = QuoteTerm::get_attr(s, features) {
-            return Ok(Quote(v));
+            return Ok(AnyTermName::Quote(v));
         } else if let Ok(v) = RoleTerm::get_attr(s, features) {
-            return Ok(Role(v));
+            return Ok(AnyTermName::Role(v));
         } else if let Ok(v) = OrdinalTerm::get_attr(s, features) {
-            return Ok(Ordinal(v));
+            return Ok(AnyTermName::Ordinal(v));
+        } else if let Ok(v) = Category::get_attr(s, features) {
+            return Ok(AnyTermName::Category(v));
         }
         Err(UnknownAttributeValue::new(s))
     }
@@ -62,7 +64,7 @@ impl GetAttribute for AnyTermName {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum SimpleTermSelector {
     Misc(MiscTerm, TermFormExtended),
-    Season(SeasonTerm, TermForm),
+    Category(Category, TermForm),
     Quote(QuoteTerm),
 }
 
@@ -72,9 +74,9 @@ impl SimpleTermSelector {
             SimpleTermSelector::Misc(t, form) => {
                 Box::new(form.fallback().map(move |x| SimpleTermSelector::Misc(t, x)))
             }
-            SimpleTermSelector::Season(t, form) => Box::new(
+            SimpleTermSelector::Category(t, form) => Box::new(
                 form.fallback()
-                    .map(move |x| SimpleTermSelector::Season(t, x)),
+                    .map(move |x| SimpleTermSelector::Category(t, x)),
             ),
             SimpleTermSelector::Quote(t) => Box::new(
                 // Quotes don't do fallback. Not spec'd, but what on earth is the long form of a
@@ -547,6 +549,42 @@ impl RoleTerm {
 /// This is all the "miscellaneous" terms from the spec, EXCEPT `edition`. Edition is the only one
 /// that matches "terms accompanying the number variables" in [option (a)
 /// here](https://docs.citationstyles.org/en/stable/specification.html#gender-specific-ordinals)
+
+#[derive(AsRefStr, EnumProperty, EnumString, Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[strum(serialize_all = "kebab_case")]
+pub enum Category {
+    Anthropology,
+    Astronomy,
+    Biology,
+    Botany,
+    Chemistry,
+    Communications,
+    Engineering,
+    /// Used for generic styles like Harvard and APA
+    GenericBase,
+    Geography,
+    Geology,
+    History,
+    Humanities,
+    Law,
+    Linguistics,
+    Literature,
+    Math,
+    Medicine,
+    Philosophy,
+    Physics,
+    /// Accepts both kebab-case and snake_case as the snake_case is anomalous
+    #[strum(serialize = "political-science", serialize = "political_science")]
+    PoliticalScience,
+    Psychology,
+    Science,
+    /// Accepts both kebab-case and snake_case as the snake_case is anomalous
+    #[strum(serialize = "social-science", serialize = "social_science")]
+    SocialScience,
+    Sociology,
+    Theology,
+    Zoology,
+}
 
 #[derive(AsRefStr, EnumProperty, EnumString, Debug, Copy, Clone, PartialEq, Eq, Hash)]
 #[strum(serialize_all = "kebab_case")]

--- a/crates/csl/src/variables.rs
+++ b/crates/csl/src/variables.rs
@@ -8,6 +8,7 @@ use super::attr::GetAttribute;
 use super::error::*;
 use super::version::Features;
 use super::IsIndependent;
+use super::Style;
 
 #[derive(Debug, Eq, Copy, Clone, PartialEq, EnumProperty, Hash)]
 pub enum AnyVariable {
@@ -310,10 +311,17 @@ pub enum NumberVariable {
 }
 
 impl NumberVariable {
-    pub fn should_replace_hyphens(self) -> bool {
+    pub fn should_replace_hyphens(self, style: &Style) -> bool {
         match self {
             NumberVariable::Locator => true,
-            NumberVariable::Page => true,
+            NumberVariable::Page => style.page_range_format.is_some(),
+            _ => false,
+        }
+    }
+    pub fn is_quantity(self) -> bool {
+        match self {
+            NumberVariable::NumberOfVolumes => true,
+            NumberVariable::NumberOfPages => true,
             _ => false,
         }
     }

--- a/crates/io/src/numeric.rs
+++ b/crates/io/src/numeric.rs
@@ -33,22 +33,6 @@ impl NumericToken {
     }
 }
 
-fn tokens_to_string(ts: &[NumericToken]) -> String {
-    let mut s = String::with_capacity(ts.len());
-    for t in ts {
-        match t {
-            // TODO: ordinals, etc
-            Num(i) => s.push_str(&format!("{}", i)),
-            Affixed(a) => s.push_str(&a),
-            Comma => s.push_str(", "),
-            // en-dash
-            Hyphen => s.push_str("\u{2013}"),
-            Ampersand => s.push_str(" & "),
-        }
-    }
-    s
-}
-
 /// Either a parsed vector of numeric tokens, or the raw string input.
 ///
 /// Relevant parts of the Spec:
@@ -119,19 +103,6 @@ impl NumericValue {
         match self {
             NumericValue::Tokens(verb, _) => verb.as_str(),
             NumericValue::Str(s) => s.as_str(),
-        }
-    }
-
-    pub fn as_number(&self, replace_hyphens: bool) -> String {
-        match self {
-            NumericValue::Tokens(_, ts) => tokens_to_string(ts),
-            NumericValue::Str(s) => {
-                if replace_hyphens {
-                    s.replace('-', "\u{2013}")
-                } else {
-                    s.clone()
-                }
-            }
         }
     }
 }

--- a/crates/io/src/numeric.rs
+++ b/crates/io/src/numeric.rs
@@ -86,7 +86,17 @@ impl NumericValue {
     }
     pub fn is_multiple(&self) -> bool {
         match *self {
-            NumericValue::Tokens(_, ref ts) => ts.len() > 1,
+            NumericValue::Tokens(_, ref ts) => {
+                match ts.len() {
+                    0 => false,
+                    1 => if let Some(NumericToken::Num(i)) = ts.get(0) {
+                        *i != 1
+                    } else {
+                        false
+                    }
+                    _ => true
+                }
+            },
 
             // TODO: fallback interpretation of "multiple" to include unparsed numerics that have
             // multiple numbers etc

--- a/crates/io/src/numeric.rs
+++ b/crates/io/src/numeric.rs
@@ -84,17 +84,21 @@ impl NumericValue {
             NumericValue::Str(_) => false,
         }
     }
-    pub fn is_multiple(&self) -> bool {
+    pub fn is_multiple(&self, var_is_quantity: bool) -> bool {
         match *self {
             NumericValue::Tokens(_, ref ts) => {
-                match ts.len() {
-                    0 => false,
-                    1 => if let Some(NumericToken::Num(i)) = ts.get(0) {
-                        *i != 1
-                    } else {
-                        false
+                if var_is_quantity {
+                    match ts.len() {
+                        0 => true, // doesn't matter
+                        1 => if let Some(NumericToken::Num(i)) = ts.get(0) {
+                            *i != 1
+                        } else {
+                            false
+                        }
+                        _ => true
                     }
-                    _ => true
+                } else {
+                    ts.len() > 1
                 }
             },
 

--- a/crates/io/src/output/markup/html.rs
+++ b/crates/io/src/output/markup/html.rs
@@ -172,7 +172,7 @@ impl FormatCmd {
             FormatCmd::VerticalAlignmentSuperscript => ("sup", ""),
             FormatCmd::VerticalAlignmentSubscript => ("sub", ""),
             FormatCmd::VerticalAlignmentBaseline => {
-                ("span", r#" style="vertical-alignment:baseline;"#)
+                ("span", r#" style="vertical-alignment:baseline;""#)
             }
         }
     }

--- a/crates/proc/src/date.rs
+++ b/crates/proc/src/date.rs
@@ -741,7 +741,7 @@ fn dp_render_string<'c, O: OutputFormat, I: OutputFormat>(
                 MonthTerm::from_u32(date.month)
                     .map(|month| locale.get_month_gender(month))
                     .map(|gender| {
-                        render_ordinal(&[NumericToken::Num(date.day)], locale, gender, false)
+                        render_ordinal(&[NumericToken::Num(date.day)], locale, None, gender, false)
                     })
             }
             // Numeric or ordinal with limit-day-ordinals-to-day-1

--- a/crates/proc/src/date.rs
+++ b/crates/proc/src/date.rs
@@ -11,12 +11,12 @@ use citeproc_io::{Date, DateOrRange};
 use csl::terms::*;
 use csl::Atom;
 use csl::LocaleDate;
-use csl::{
-    BodyDate, DatePart, DatePartForm, DateParts, DateVariable, DayForm, IndependentDate, Locale,
-    LocalizedDate, MonthForm, SortKey, YearForm,
-};
 #[cfg(test)]
 use csl::RangeDelimiter;
+use csl::{
+    BodyDate, DatePart, DatePartForm, DateParts, DateVariable, DayForm, IndependentDate, Locale,
+    LocalizedDate, MonthForm, NumberVariable, SortKey, YearForm,
+};
 #[cfg(test)]
 use pretty_assertions::assert_eq;
 use std::fmt::Write;
@@ -741,7 +741,16 @@ fn dp_render_string<'c, O: OutputFormat, I: OutputFormat>(
                 MonthTerm::from_u32(date.month)
                     .map(|month| locale.get_month_gender(month))
                     .map(|gender| {
-                        render_ordinal(&[NumericToken::Num(date.day)], locale, None, gender, false)
+                        // the specific number variable does not matter as the tokens do not
+                        // contain any hyphens to pick \u{2013} for
+                        render_ordinal(
+                            &[NumericToken::Num(date.day)],
+                            locale,
+                            NumberVariable::Number,
+                            None,
+                            gender,
+                            false,
+                        )
                     })
             }
             // Numeric or ordinal with limit-day-ordinals-to-day-1

--- a/crates/proc/src/disamb/implementation.rs
+++ b/crates/proc/src/disamb/implementation.rs
@@ -159,7 +159,7 @@ impl Disambiguation<Markup> for Element {
                             } else {
                                 state.maybe_suppress_num(v);
                                 ctx.get_number(v)
-                                    .map(|val| renderer.text_variable(text, var, val.verbatim()))
+                                    .map(|val| renderer.text_number_variable(text, v, &val))
                             }
                         }
                     };

--- a/crates/proc/src/element.rs
+++ b/crates/proc/src/element.rs
@@ -116,9 +116,8 @@ where
                                     None
                                 } else {
                                     state.maybe_suppress_num(v);
-                                    ctx.get_number(v).map(|val| {
-                                        renderer.text_variable(text, var, val.verbatim())
-                                    })
+                                    ctx.get_number(v)
+                                        .map(|val| renderer.text_number_variable(text, v, &val))
                                 }
                             }
                         };

--- a/crates/proc/src/lib.rs
+++ b/crates/proc/src/lib.rs
@@ -26,6 +26,7 @@ mod helpers;
 mod ir;
 mod names;
 mod number;
+mod page_range;
 mod renderer;
 mod sort;
 mod unicode;

--- a/crates/proc/src/number.rs
+++ b/crates/proc/src/number.rs
@@ -1,13 +1,23 @@
 use citeproc_io::NumericToken::{self, *};
 use citeproc_io::NumericValue;
-use csl::{Gender, Locale, OrdinalTerm, MiscTerm, TermFormExtended, SimpleTermSelector, OrdinalTermSelector, PageRangeFormat};
+use csl::{
+    Gender, Locale, MiscTerm, OrdinalTerm, OrdinalTermSelector, PageRangeFormat,
+    SimpleTermSelector, TermFormExtended, NumberVariable,
+};
+use std::fmt::Write;
 
-pub fn render_ordinal(ts: &[NumericToken], locale: &Locale, prf: Option<PageRangeFormat>, gender: Gender, long: bool) -> String {
+pub fn render_ordinal(
+    ts: &[NumericToken],
+    locale: &Locale,
+    variable: NumberVariable,
+    prf: Option<PageRangeFormat>,
+    gender: Gender,
+    long: bool,
+) -> String {
     let mut s = String::new();
     for token in ts {
         match *token {
             NumericToken::Num(n) => {
-                use std::fmt::Write;
                 if !long || n == 0 || n > 10 {
                     write!(s, "{}", n).unwrap();
                 }
@@ -19,7 +29,7 @@ pub fn render_ordinal(ts: &[NumericToken], locale: &Locale, prf: Option<PageRang
             Affixed(ref a) => s.push_str(&a),
             Comma => s.push_str(", "),
             // en-dash
-            Hyphen => s.push_str(get_hyphen(locale, prf.is_some())),
+            Hyphen => s.push_str(get_hyphen(locale, variable)),
             Ampersand => {
                 s.push(' ');
                 s.push_str(get_ampersand(locale));
@@ -40,25 +50,52 @@ fn get_ampersand(locale: &Locale) -> &str {
     }
 }
 
-fn get_hyphen(locale: &Locale, is_page: bool) -> &str {
-    let sel = SimpleTermSelector::Misc(MiscTerm::PageRangeDelimiter, TermFormExtended::Symbol);
-    if is_page {
-        if let Some(amp) = locale.get_simple_term(sel) {
-            return amp.singular().trim();
-        }
+pub fn get_hyphen(locale: &Locale, variable: NumberVariable) -> &str {
+    // A few more than the spec's list of en-dashable variables
+    // https://github.com/Juris-M/citeproc-js/blob/1aa49dd2ab9a1c85d3060073780d65c86754a438/src/util_number.js#L584
+    let get = |term: MiscTerm| {
+        let sel = SimpleTermSelector::Misc(term, TermFormExtended::Symbol);
+        locale.get_simple_term(sel)
+            .map(|amp| amp.singular().trim())
+            .unwrap_or("\u{2013}")
+    };
+    match variable {
+        NumberVariable::Page
+        | NumberVariable::Locator
+        | NumberVariable::Issue
+        | NumberVariable::Volume
+        | NumberVariable::Edition
+        | NumberVariable::Number => get(MiscTerm::PageRangeDelimiter),
+        NumberVariable::CollectionNumber => get(MiscTerm::YearRangeDelimiter),
+        _ => "-",
     }
-    "\u{2013}"
 }
 
-pub fn arabic_number(num: &NumericValue, locale: &Locale, prf: Option<PageRangeFormat>) -> String {
+#[test]
+fn test_get_hyphen() {
+    let loc = &Locale::default();
+    assert_eq!(get_hyphen(loc, NumberVariable::Locator), "\u{2013}");
+}
+
+pub fn arabic_number(
+    num: &NumericValue,
+    locale: &Locale,
+    variable: NumberVariable,
+    prf: Option<PageRangeFormat>,
+) -> String {
     debug!("{:?}", num);
     match num {
-        NumericValue::Tokens(_, ts) => tokens_to_string(ts, locale, prf),
+        NumericValue::Tokens(_, ts) => tokens_to_string(ts, locale, variable, prf),
         NumericValue::Str(s) => s.to_owned(),
     }
 }
 
-fn tokens_to_string(ts: &[NumericToken], locale: &Locale, prf: Option<PageRangeFormat>) -> String {
+fn tokens_to_string(
+    ts: &[NumericToken],
+    locale: &Locale,
+    variable: NumberVariable,
+    prf: Option<PageRangeFormat>,
+) -> String {
     let mut s = String::with_capacity(ts.len());
     #[derive(Copy, Clone)]
     enum NumBefore {
@@ -76,28 +113,20 @@ fn tokens_to_string(ts: &[NumericToken], locale: &Locale, prf: Option<PageRangeF
                         (crate::page_range::truncate_prf(prf, prev, i), None)
                     }
                     _ => (i, Some(NumBefore::SeenNum(i))),
-
                 };
-                s.push_str(&format!("{}", cropped));
+                write!(s, "{}", cropped).unwrap();
                 newstate
             }
             Affixed(ref a) => {
                 s.push_str(&a);
                 None
-            },
+            }
             Comma => {
                 s.push_str(", ");
                 None
             }
             Hyphen => {
-                let mut hyphen = "-"; // actual hyphen
-                if prf.is_some() {
-                    if let Some(NumBefore::SeenNum(_)) = state {
-                        if let Some(Num(_)) = iter.peek() {
-                            hyphen = get_hyphen(locale, prf.is_some());
-                        }
-                    }
-                }
+                let mut hyphen = get_hyphen(locale, variable);
                 s.push_str(hyphen);
                 match state {
                     Some(NumBefore::SeenNum(i)) => Some(NumBefore::SeenNumHyphen(i)),
@@ -126,7 +155,7 @@ pub fn roman_representable(val: &NumericValue) -> bool {
     }
 }
 
-pub fn roman_lower(ts: &[NumericToken], locale: &Locale, prf: Option<PageRangeFormat>) -> String {
+pub fn roman_lower(ts: &[NumericToken], locale: &Locale, variable: NumberVariable, prf: Option<PageRangeFormat>) -> String {
     let mut s = String::with_capacity(ts.len() * 2); // estimate
     use std::convert::TryInto;
     for t in ts {
@@ -140,7 +169,7 @@ pub fn roman_lower(ts: &[NumericToken], locale: &Locale, prf: Option<PageRangeFo
             Affixed(a) => s.push_str(&a),
             Comma => s.push_str(", "),
             // en-dash
-            Hyphen => s.push_str(get_hyphen(locale, prf.is_some())),
+            Hyphen => s.push_str(get_hyphen(locale, variable)),
             Ampersand => {
                 s.push(' ');
                 s.push_str(get_ampersand(locale));
@@ -160,7 +189,10 @@ fn test_roman_lower() {
         NumericToken::Comma,
         NumericToken::Affixed("2E".into()),
     ];
-    assert_eq!(&roman_lower(&ts[..], &Locale::default(), None), "iii\u{2013}xi, 2E");
+    assert_eq!(
+        &roman_lower(&ts[..], &Locale::default(), None),
+        "iii\u{2013}xi, 2E"
+    );
 }
 
 #[allow(dead_code)]

--- a/crates/proc/src/page_range.rs
+++ b/crates/proc/src/page_range.rs
@@ -1,0 +1,169 @@
+use csl::PageRangeFormat;
+
+/// Returns the second number with the page range format applied.
+pub fn truncate_prf(prf: PageRangeFormat, first: u32, mut second: u32) -> u32 {
+    second = expand(first, second);
+    match prf {
+        PageRangeFormat::Chicago => {
+            let mod100 = first % 100;
+            let delta = second - first;
+            if first < 100 || mod100 == 0 {
+                second
+            } else if mod100 < 10 && delta < 90 {
+                truncate_diff(first, second, 1)
+            } else if closest_smaller_power_of_10(first) == 1000 {
+                let chopped = truncate_diff(first, second, 2);
+                if closest_smaller_power_of_10(chopped) == 100 {
+                    // force 4 digits if 3 are different
+                    return truncate_diff(first, second, 4)
+                }
+                chopped
+            } else {
+                truncate_diff(first, second, 2)
+            }
+        }
+        PageRangeFormat::Minimal => {
+            truncate_diff(first, second, 1)
+        }
+        PageRangeFormat::MinimalTwo => {
+            truncate_diff(first, second, 2)
+        }
+        PageRangeFormat::Expanded => {
+            second
+        }
+    }
+}
+
+#[test]
+fn page_range_chicago() {
+    fn go(a: u32, b: u32) -> u32 {
+        truncate_prf(PageRangeFormat::Chicago, a, b)
+    }
+    // https://docs.citationstyles.org/en/stable/specification.html#appendix-v-page-range-formats
+    // 1
+    assert_eq!(go(3, 10), 10);
+    assert_eq!(go(71, 72), 72);
+    // 2
+    assert_eq!(go(100, 104), 104);
+    assert_eq!(go(600, 613), 613);
+    assert_eq!(go(1100, 1123), 1123);
+    // 3
+    assert_eq!(go(101, 108), 8);
+    assert_eq!(go(107, 108), 8);
+    assert_eq!(go(505, 517), 17);
+    assert_eq!(go(1002, 1006), 6);
+    // 4
+    assert_eq!(go(321, 325), 25);
+    assert_eq!(go(415, 532), 532);
+    assert_eq!(go(11564, 11568), 68);
+    assert_eq!(go(13792, 13803), 803);
+    // 5 (force 4 digits where 3 are different)
+    assert_eq!(go(1496, 1504), 1504);
+    assert_eq!(go(2787, 2816), 2816);
+    // but if only two digits different, don't
+    assert_eq!(go(1486, 1496), 96);
+}
+
+#[test]
+fn test_truncate_diff() {
+    assert_eq!(truncate_diff(101, 105, 1), 5);
+    assert_eq!(truncate_diff(121, 125, 1), 5);
+    assert_eq!(truncate_diff(121, 125, 2), 25);
+    assert_eq!(truncate_diff(121, 125, 3), 125);
+}
+
+fn truncate_diff(a: u32, b: u32, min: u32) -> u32 {
+    if b < a {
+        return b;
+    }
+    let mut diff_started = false;
+    let mut acc = 0u32;
+    let mut iter_a = DigitsBase10::new(a);
+    let mut iter_b = DigitsBase10::new(b);
+    // fast forward iter_a until they have the same mask i.e. same remaining digit length
+    while iter_a.mask > iter_b.mask {
+        iter_a.next();
+    }
+    while iter_b.mask > iter_a.mask {
+        if let Some(b_dig) = iter_b.next() {
+            diff_started = true;
+            acc *= 10;
+            acc += b_dig as u32;
+        }
+    }
+    let min_mask = 10_u32.pow(min);
+    if iter_a.mask * 10 == min_mask {
+        diff_started = true;
+    }
+    // Primitive zip so we can keep access to iter_a
+    while let (Some(a_dig), Some(b_dig)) = (iter_a.next(), iter_b.next()) {
+        if diff_started || a_dig != b_dig {
+            diff_started = true;
+            acc *= 10;
+            acc += b_dig as u32;
+        }
+        if iter_a.mask * 10 == min_mask {
+            diff_started = true;
+        }
+    }
+    acc
+}
+
+#[test]
+fn test_expand() {
+    assert_eq!(expand(103, 4), 104);
+    assert_eq!(expand(133, 4), 134);
+    assert_eq!(expand(133, 54), 154);
+}
+
+fn expand(a: u32, b: u32) -> u32 {
+    let mask = closest_smaller_power_of_10(b) * 10;
+    (a - (a % mask)) + (b % mask)
+}
+
+// Thanks to timotree3 on the Rust users forum for writing this already
+// https://users.rust-lang.org/t/iterate-through-digits-of-a-number/34465/9
+
+pub struct DigitsBase10 {
+    mask: u32,
+    num: u32,
+}
+
+impl Iterator for DigitsBase10 {
+    type Item = u8;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.mask == 0 {
+            return None;
+        }
+
+        let digit = self.num / self.mask % 10;
+        self.mask /= 10;
+
+        Some(digit as u8)
+    }
+}
+
+fn closest_smaller_power_of_10(num: u32) -> u32 {
+    let answer = 10_f64.powf((num as f64).log10().floor()) as u32;
+
+    // these properties need to hold. I think they do, but the float conversions
+    // might mess things up...
+    debug_assert!(answer <= num);
+    debug_assert!(answer > num / 10);
+    answer
+}
+
+impl DigitsBase10 {
+    pub fn new(num: u32) -> Self {
+        let mask = if num == 0 {
+            1
+        } else {
+            closest_smaller_power_of_10(num)
+        };
+
+        DigitsBase10 { mask, num }
+    }
+}
+
+

--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -236,7 +236,9 @@ impl LocaleFetcher for Filesystem {
 pub fn normalise_html(strg: &str) -> String {
     strg.replace("&#x2f;", "/")
         .replace("&#x27;", "'")
+        .replace("&#60;", "&lt;")
+        .replace("&#62;", "&gt;")
         .replace("&quot;", "\"")
         // citeproc-js uses the #38 version
-        .replace("&amp;", "&#38;")
+        .replace("&#38;", "&amp;")
 }

--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -241,4 +241,7 @@ pub fn normalise_html(strg: &str) -> String {
         .replace("&quot;", "\"")
         // citeproc-js uses the #38 version
         .replace("&#38;", "&amp;")
+        // citeproc-js puts successive unicode superscript transforms in their own tags,
+        // citeproc-rs joins them.
+        .replace("</sup><sup>", "")
 }


### PR DESCRIPTION
Page range formatting, implemented without allocating, using a neat digit-iterator trick from someone on the Rust user forums (credited).

Includes a number of HTML normalisations and style fixes that helped make some of the page-range tests pass.

There are a few unspecified behaviours which don't pass -- mostly weird composite affixed numbers. Mostly the remainder just calls for a slightly more permissive numeric value parser. (E.g. people putting en-dashes in there already, etc.)

1 regression: `csl_test_suite::number_LeadingZeros.txt` as page ranges are now numeric nearly all of the time. Maybe this would be fixed by adding a leading-zeroes count to NumericToken::Num.

```
test result: 1 regressions, 20 new passing tests, 1 new ignores, 19 outputs changed, out of 881 intersecting tests
```