### PR TITLE
Citation Labels and Year-Suffixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,6 +272,7 @@ dependencies = [
  "smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "strum 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ucd-trie 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unic-segment 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/crates/citeproc/tests/data/ignore.txt
+++ b/crates/citeproc/tests/data/ignore.txt
@@ -22,3 +22,8 @@ variables_TitleShortOnAbbrevWithTitle.txt
 variables_ShortForm.txt
 # citeproc-js feature
 sort_CitationUnsorted.txt
+# BIBENTRIES
+api_UpdateItemsDeleteDecrementsByCiteDisambiguation.txt
+sort_CitationEdit.txt
+api_UpdateItemsReshuffle.txt
+api_UpdateItemsDelete.txt

--- a/crates/csl/src/variables.rs
+++ b/crates/csl/src/variables.rs
@@ -88,6 +88,8 @@ impl IsIndependent for AnyVariable {
 impl IsIndependent for Variable {
     fn is_independent(&self) -> bool {
         match self {
+            // Variable::CitationLabel is not independent, it just implies a YearSuffix
+            // which is, and that is handled in FreeCondWalker::text_variable()
             Variable::LocatorExtra
             | Variable::YearSuffix
             | Variable::Hereinafter => true,

--- a/crates/csl/src/variables.rs
+++ b/crates/csl/src/variables.rs
@@ -89,7 +89,6 @@ impl IsIndependent for Variable {
     fn is_independent(&self) -> bool {
         match self {
             Variable::LocatorExtra
-            | Variable::CitationLabel
             | Variable::YearSuffix
             | Variable::Hereinafter => true,
             _ => false,

--- a/crates/db/src/cite.rs
+++ b/crates/db/src/cite.rs
@@ -7,13 +7,11 @@
 use super::xml::{LocaleDatabase, StyleDatabase};
 
 use csl::Locale;
-use csl::Position;
-use fnv::FnvHashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
 
 use citeproc_io::output::markup::Markup;
-use citeproc_io::{Cite, ClusterId, ClusterNumber, IntraNote, Reference};
+use citeproc_io::{Cite, ClusterId, ClusterNumber, Reference};
 use csl::Atom;
 
 #[salsa::query_group(CiteDatabaseStorage)]

--- a/crates/io/src/names.rs
+++ b/crates/io/src/names.rs
@@ -6,7 +6,7 @@
 
 // kebab-case here is the same as Strum's "kebab_case",
 // but with a more accurate name
-#[derive(Debug, Eq, PartialEq, Hash, Serialize, Deserialize, Clone)]
+#[derive(Default, Debug, Eq, PartialEq, Hash, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "kebab-case")]
 pub struct PersonName {
     pub family: Option<String>,

--- a/crates/io/src/output/markup/move_punctuation.rs
+++ b/crates/io/src/output/markup/move_punctuation.rs
@@ -222,7 +222,6 @@ fn move_around_quote(els: &mut Vec<InlineElement>, ix: usize, piq: bool) -> Opti
     debug!("move_around_quote {:?} {:?} {:?}", els.get(ix), ix, piq);
     if let Some(mut insertion_point) = find_right_quote(els, ix, piq) {
         // Last element burrowed down to a right quotation mark
-        let mut needs_removal = false;
         let mut has_two_puncs = None;
         let mut outside_char = {
             let suffix = insertion_point.next_string_mut()?;

--- a/crates/proc/Cargo.toml
+++ b/crates/proc/Cargo.toml
@@ -27,6 +27,7 @@ parking_lot = "0.9.0"
 # don't need lexical as it is only used to parse floats
 nom = { version = "5.0.1", default-features = false, features = ["std"] }
 unicase = "2.6.0"
+unic-segment = "0.9.0"
 
 [dev-dependencies]
 lazy_static = "1.4.0"

--- a/crates/proc/src/choose.rs
+++ b/crates/proc/src/choose.rs
@@ -33,6 +33,7 @@ where
                         choose: self.clone(),
                         done: false,
                         ir: Box::new(content),
+                        group_vars: gv,
                     }))),
                     gv,
                 )

--- a/crates/proc/src/citation_label.rs
+++ b/crates/proc/src/citation_label.rs
@@ -1,0 +1,183 @@
+use citeproc_io::{Reference, Name, PersonName, DateOrRange, Date};
+use csl::{NameVariable, DateVariable};
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Trigraph(Vec<Vec<ConfigCell>>);
+
+impl Trigraph {
+    pub fn parse(s: &str) -> Result<Self, ()> {
+        parser::colon_separated(s)
+            .map_err(|_| ())
+            .and_then(|(remain, x)| {
+                if remain.is_empty() {
+                    Ok(Trigraph(x))
+                } else {
+                    Err(())
+                }
+            })
+    }
+    pub fn make_label(&self, refr: &Reference) -> String {
+        let mut string = String::with_capacity(6);
+        let authors = refr.name.get(&NameVariable::Author);
+        let issued = refr.date.get(&DateVariable::Issued);
+        if self.0.len() == 0 {
+            return string;
+        }
+        use unic_segment::Graphemes;
+        use std::fmt::Write;
+        if let Some(authors) = authors {
+            let count = authors.len();
+            let ix = std::cmp::min(count, self.0.len()) - 1;
+            if count > 0 {
+                let mut prog = 0usize;
+                for author_printer in self.0[ix].iter().filter_map(|cell| match cell {
+                    ConfigCell::Author { first_n_letters } => Some(*first_n_letters),
+                    _ => None,
+                }) {
+                    let name_to_write = match &authors[prog] {
+                        Name::Literal { literal } => literal,
+                        Name::Person(PersonName {
+                            family: Some(family),
+                            ..
+                        }) => family,
+                        Name::Person(PersonName {
+                            family: None,
+                            given: Some(given),
+                            ..
+                        }) => given,
+                        _ => {
+                            prog += 1;
+                            continue;
+                        },
+                    };
+                    let len = Graphemes::new(name_to_write).take(author_printer as usize).fold(0, |acc, x| acc + x.len());
+                    write!(string, "{}", &name_to_write[..len]).unwrap();
+                    prog += 1;
+                }
+            }
+            if let Some(issued) = issued {
+                if let Some(single) = issued.single_or_first() {
+                    for year_digits in self.0[ix].iter().filter_map(|cell| match cell {
+                        ConfigCell::Year { last_n_digits } => Some(*last_n_digits),
+                        _ => None,
+                    }) {
+                        // Probably behaves weirdly for BC dates
+                        write!(string, "{:02}", single.year % (10i32.pow(year_digits))).unwrap();
+                    }
+                }
+            }
+        }
+        string
+    }
+}
+
+impl Default for Trigraph {
+    fn default() -> Self {
+        Trigraph::parse("Aaaa00:AaAa00:AaAA00:AAAA00").expect("Trigraph ought to parse the default!")
+    }
+}
+
+#[test]
+fn test_write_label() {
+    let trigraph = Trigraph::default();
+    use csl::CslType;
+    let mut refr = Reference::empty("ref_id".into(), CslType::Book);
+    refr.name.insert(NameVariable::Author, vec![
+        Name::Person(PersonName {
+            family: Some("Jobs".to_owned()),
+            ..Default::default()
+        })
+    ]);
+    refr.date.insert(DateVariable::Issued, DateOrRange::Single(Date::new(1995, 0, 0)));
+    assert_eq!(trigraph.make_label(&refr), "Jobs95".to_owned());
+    refr.name.insert(NameVariable::Author, vec![
+        Name::Person(PersonName {
+            family: Some("Boris".to_owned()),
+            ..Default::default()
+        }),
+        Name::Person(PersonName {
+            family: Some("Johnson".to_owned()),
+            ..Default::default()
+        })
+    ]);
+    assert_eq!(trigraph.make_label(&refr), "BoJo95".to_owned());
+}
+
+#[test]
+fn test_parse_trigraph() {
+    assert_eq!(
+        Trigraph::parse("Aaaa00:AaAa00:AaAA00:AAAA00"),
+        Ok(Trigraph(vec![
+            vec![
+                ConfigCell::Author { first_n_letters: 4 },
+                ConfigCell::Year { last_n_digits: 2 },
+            ],
+            vec![
+                ConfigCell::Author { first_n_letters: 2 },
+                ConfigCell::Author { first_n_letters: 2 },
+                ConfigCell::Year { last_n_digits: 2 },
+            ],
+            vec![
+                ConfigCell::Author { first_n_letters: 2 },
+                ConfigCell::Author { first_n_letters: 1 },
+                ConfigCell::Author { first_n_letters: 1 },
+                ConfigCell::Year { last_n_digits: 2 },
+            ],
+            vec![
+                ConfigCell::Author { first_n_letters: 1 },
+                ConfigCell::Author { first_n_letters: 1 },
+                ConfigCell::Author { first_n_letters: 1 },
+                ConfigCell::Author { first_n_letters: 1 },
+                ConfigCell::Year { last_n_digits: 2 },
+            ],
+        ]))
+    )
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum ConfigCell {
+    Author { first_n_letters: u32 },
+    Year { last_n_digits: u32 },
+}
+
+mod parser {
+    use super::*;
+    use nom::{
+        branch::alt,
+        bytes::complete::{take_while, take_while1, take_while_m_n},
+        character::complete::char,
+        combinator::{map, opt, recognize},
+        multi::{many1, separated_nonempty_list},
+        IResult,
+    };
+
+    fn author(inp: &str) -> IResult<&str, ConfigCell> {
+        let (rest, cap) = char('A')(inp)?;
+        let (rest, lowers) = recognize(take_while(|c: char| c == 'a'))(rest)?;
+        Ok((
+            rest,
+            ConfigCell::Author {
+                first_n_letters: 1 + lowers.len() as u32,
+            },
+        ))
+    }
+
+    fn year(inp: &str) -> IResult<&str, ConfigCell> {
+        let (rest, zeroes) = recognize(take_while1(|c| c == '0'))(inp)?;
+        Ok((
+            rest,
+            ConfigCell::Year {
+                last_n_digits: zeroes.len() as u32,
+            },
+        ))
+    }
+
+    #[test]
+    fn test_author() {
+        assert_eq!(author("Aaaa"), Ok(("", ConfigCell::Author { first_n_letters: 4 })))
+    }
+
+    pub(super) fn colon_separated(inp: &str) -> IResult<&str, Vec<Vec<ConfigCell>>> {
+        separated_nonempty_list(char(':'), many1(alt((author, year))))(inp)
+    }
+}

--- a/crates/proc/src/date.rs
+++ b/crates/proc/src/date.rs
@@ -22,6 +22,7 @@ use pretty_assertions::assert_eq;
 use std::fmt::Write;
 use std::mem;
 
+#[derive(Debug)]
 enum Either<O: OutputFormat> {
     Build(Option<O::Build>),
     /// We will convert this to RefIR as necessary. It will only contain Outputs and
@@ -31,10 +32,13 @@ enum Either<O: OutputFormat> {
 }
 
 impl<O: OutputFormat> Either<O> {
-    fn into_cite_ir(self) -> IrSum<O> {
+    fn into_cite_ir(self, var: DateVariable) -> IrSum<O> {
         match self {
             Either::Build(opt) => {
-                let content = opt.map(CiteEdgeData::Output);
+                // Get CiteEdgeData::Accessed if it's DateVariable::Accessed
+                // We guarantee below in dp_render_either that Accessed will not produce Either::Ir
+                let mapper = CiteEdgeData::from_date_variable(var);
+                let content = opt.map(mapper);
                 let gv = GroupVars::rendered_if(content.is_some());
                 (IR::Rendered(content), gv)
             }
@@ -58,7 +62,7 @@ fn to_ref_ir(
 ) -> RefIR {
     match ir {
         // Either Rendered(Some(CiteEdgeData::YearSuffix)) or explicit year suffixes can end up as
-        // EdgeData::YearSuffix edges in RefIR. Because we don't care whether it's been rendered or
+        // EdgeData::YearSuffixPlain edges in RefIR. Because we don't care whether it's been rendered or
         // not -- in RefIR's comparison, it must always be an EdgeData::YearSuffix.
         IR::Rendered(opt_build) => RefIR::Edge(to_edge(opt_build, stack)),
         IR::YearSuffix(_ys) => RefIR::Edge(Some(ys_edge)),
@@ -90,7 +94,7 @@ impl Either<Markup> {
             |opt_cite_edge: Option<CiteEdgeData<Markup>>, stack: Formatting| -> Option<Edge> {
                 opt_cite_edge.map(|cite_edge| db.edge(cite_edge.to_edge_data(fmt, stack)))
             };
-        let ys_edge = db.edge(EdgeData::YearSuffix);
+        let ys_edge = db.edge(EdgeData::YearSuffixPlain);
         match self {
             Either::Build(opt) => {
                 let content = opt.map(CiteEdgeData::Output);
@@ -121,12 +125,19 @@ where
         _state: &mut IrState,
         ctx: &CiteContext<'c, O, I>,
     ) -> IrSum<O> {
-        match self {
-            BodyDate::Indep(idate) => intermediate_generic_indep(idate, GenericContext::Cit(ctx)),
-            BodyDate::Local(ldate) => intermediate_generic_local(ldate, GenericContext::Cit(ctx)),
-        }
-        .map(Either::into_cite_ir)
-        .unwrap_or((IR::Rendered(None), GroupVars::rendered_if(false)))
+        let (either, var) = match self {
+            BodyDate::Indep(idate) => (
+                intermediate_generic_indep(idate, GenericContext::Cit(ctx)),
+                idate.variable
+            ),
+            BodyDate::Local(ldate) => (
+                intermediate_generic_local(ldate, GenericContext::Cit(ctx)),
+                ldate.variable
+            ),
+        };
+        either
+            .map(|e| e.into_cite_ir(var))
+            .unwrap_or((IR::Rendered(None), GroupVars::rendered_if(false)))
     }
 }
 
@@ -139,16 +150,24 @@ impl Disambiguation<Markup> for BodyDate {
         stack: Formatting,
     ) -> (RefIR, GroupVars) {
         let _fmt = ctx.format;
-        match self {
-            BodyDate::Indep(idate) => {
-                intermediate_generic_indep::<Markup, Markup>(idate, GenericContext::Ref(ctx))
-            }
-            BodyDate::Local(ldate) => {
-                intermediate_generic_local::<Markup, Markup>(ldate, GenericContext::Ref(ctx))
-            }
+        let (either, var) = match self {
+            BodyDate::Indep(idate) => (
+                intermediate_generic_indep::<Markup, Markup>(idate, GenericContext::Ref(ctx)),
+                idate.variable,
+            ),
+            BodyDate::Local(ldate) => (
+                intermediate_generic_local::<Markup, Markup>(ldate, GenericContext::Ref(ctx)),
+                ldate.variable,
+            ),
+        };
+        if var == DateVariable::Accessed {
+            either
+                .map(|_| (RefIR::Edge(Some(db.edge(EdgeData::Accessed))), GroupVars::Important))
+        } else {
+            either
+                .map(|e| e.into_ref_ir(db, ctx, stack))
         }
-        .map(|e| e.into_ref_ir(db, ctx, stack))
-        .unwrap_or((RefIR::Edge(None), GroupVars::rendered_if(false)))
+        .unwrap_or((RefIR::Edge(None), GroupVars::Missing))
     }
 }
 
@@ -208,8 +227,7 @@ impl<'a, O: OutputFormat> PartBuilder<O> {
                 self.upgrade();
                 match &mut self.acc {
                     PartAccumulator::Seq(ref mut seq) => {
-                        seq.recompute_group_vars();
-                        seq.contents.push((ir, seq.overall_group_vars()));
+                        seq.contents.push((ir, GroupVars::Important));
                     }
                     _ => unreachable!(),
                 }
@@ -233,20 +251,18 @@ impl<'a, O: OutputFormat> PartBuilder<O> {
                 if each.is_empty() {
                     return Either::Build(None);
                 }
-                let built = fmt.affixed(
+                let mut built = fmt.affixed(
                     fmt.group(each, "", bits.overall_formatting),
                     bits.overall_affixes.as_ref(),
                 );
+                let options = IngestOptions {
+                    text_case: bits.overall_text_case,
+                    ..Default::default()
+                };
                 if bits.overall_text_case != TextCase::None {
-                    // apply text casing by surrounding with an IrSeq,
-                    Either::Ir(IR::Seq(IrSeq {
-                        contents: vec![(IR::Rendered(Some(CiteEdgeData::Output(built))), GroupVars::Important)],
-                        text_case: bits.overall_text_case,
-                        ..Default::default()
-                    }))
-                } else {
-                    Either::Build(Some(built))
+                    fmt.apply_text_case(&mut built, &options);
                 }
+                Either::Build(Some(built))
             }
             PartAccumulator::Seq(seq) => Either::Ir(IR::Seq(seq)),
         }
@@ -389,7 +405,7 @@ fn build_parts<'c, O: OutputFormat, I: OutputFormat>(
                     true
                 }
             })
-            .filter_map(|dp| dp_render_either(dp, ctx.clone(), single, false));
+            .filter_map(|dp| dp_render_either(var, dp, ctx.clone(), single, false));
         let mut seen_one = false;
         for (_form, either) in each {
             if seen_one && !delim.is_empty() {
@@ -435,7 +451,7 @@ fn build_parts<'c, O: OutputFormat, I: OutputFormat>(
                         }
                         last_rdel = false;
                         if let Some((_form, either)) =
-                            dp_render_either(part, ctx.clone(), date, is_max_diff)
+                            dp_render_either(var, part, ctx.clone(), date, is_max_diff)
                         {
                             builder.push_either(either);
                         }
@@ -642,6 +658,7 @@ fn dp_matches(part: &DatePart, selector: DateParts) -> bool {
 }
 
 fn dp_render_either<'c, O: OutputFormat, I: OutputFormat>(
+    var: DateVariable,
     part: &DatePart,
     ctx: GenericContext<'c, O, I>,
     date: &Date,
@@ -655,42 +672,45 @@ fn dp_render_either<'c, O: OutputFormat, I: OutputFormat>(
     let string = dp_render_string(part, &ctx, date);
     string
         .map(|s| {
+            let mut affixes = part.affixes.clone();
+            if is_max_diff {
+                if let Some(ref mut aff) = affixes {
+                    aff.suffix = Atom::from("");
+                }
+            }
             if let DatePartForm::Year(_) = part.form {
-                Either::Ir({
-                    let year_part = IR::Rendered(Some(CiteEdgeData::Output(fmt.plain(&s))));
+                if var == DateVariable::Accessed {
+                    let b = fmt.affixed_text(s, part.formatting, affixes.as_ref());
+                    Either::Build(Some(b))
+                } else {
                     let mut contents = Vec::with_capacity(2);
+                    let b = fmt.plain(&s);
+                    let year_part = IR::Rendered(Some(CiteEdgeData::Output(b)));
                     // Important because we got it from a date variable.
-                    // Hence Unresolved below doesn't affect anything
                     contents.push((year_part, GroupVars::Important));
+                    // Why not move this if branch up and emit Either::Build?
+                    //
+                    // We don't emit Either::Build for normal date vars with
+                    // ctx.should_add_year_suffix_hook, because otherwise there is a mismatch
+                    // between the edges produced by {cite with year-suffix not filled} and RefIR,
+                    // specifically when affixes are nonzero. Like: ["(", "1986", ")"] vs
+                    // ["(1986)"]
                     if ctx.should_add_year_suffix_hook() {
-                        let hook = YearSuffixHook::Plain;
                         let suffix = IR::YearSuffix(YearSuffix {
-                            hook,
-                            group_vars: GroupVars::UnresolvedMissing,
+                            hook: YearSuffixHook::Plain,
+                            group_vars: GroupVars::Unresolved,
                             ir: Box::new(IR::Rendered(None))
                         });
-                        contents.push((suffix, GroupVars::UnresolvedMissing));
+                        contents.push((suffix, GroupVars::Unresolved));
                     }
-                    let mut affixes = part.affixes.clone();
-                    if is_max_diff {
-                        if let Some(ref mut aff) = affixes {
-                            aff.suffix = Atom::from("");
-                        }
-                    }
-                    IR::Seq(IrSeq {
+                    Either::Ir(IR::Seq(IrSeq {
                         contents,
                         affixes,
                         formatting: part.formatting,
                         ..Default::default()
-                    })
-                })
-            } else {
-                let mut affixes = part.affixes.clone();
-                if is_max_diff {
-                    if let Some(ref mut aff) = affixes {
-                        aff.suffix = Atom::from("");
-                    }
+                    }))
                 }
+            } else {
                 let options = IngestOptions {
                     text_case: part.text_case.unwrap_or_default(),
                     ..Default::default()

--- a/crates/proc/src/date.rs
+++ b/crates/proc/src/date.rs
@@ -759,7 +759,7 @@ fn dp_render_string<'c, O: OutputFormat, I: OutputFormat>(
     let locale = ctx.locale();
     match part.form {
         DatePartForm::Year(form) => Some(render_year(date.year, form, ctx.locale())),
-        DatePartForm::Month(form, _strip_periods) => match form {
+        DatePartForm::Month(form, strip_periods) => match form {
             MonthForm::Numeric => {
                 if date.month == 0 || date.month > 12 {
                     None
@@ -776,20 +776,23 @@ fn dp_render_string<'c, O: OutputFormat, I: OutputFormat>(
             }
             _ => {
                 let sel = GenderedTermSelector::from_month_u32(date.month, form)?;
-                Some(
-                    locale
-                        .gendered_terms
-                        .get(&sel)
-                        .map(|gt| gt.0.singular().to_string())
-                        .unwrap_or_else(|| {
-                            let fallback = if form == MonthForm::Short {
-                                MONTHS_SHORT
-                            } else {
-                                MONTHS_LONG
-                            };
-                            fallback[date.month as usize].to_string()
-                        }),
-                )
+                let string = locale
+                    .gendered_terms
+                    .get(&sel)
+                    .map(|gt| gt.0.singular().to_string())
+                    .unwrap_or_else(|| {
+                        let fallback = if form == MonthForm::Short {
+                            MONTHS_SHORT
+                        } else {
+                            MONTHS_LONG
+                        };
+                        fallback[date.month as usize].to_string()
+                    });
+                Some(if strip_periods {
+                    string.replace('.', "")
+                } else {
+                    string
+                })
             }
         },
         DatePartForm::Day(form) => match form {

--- a/crates/proc/src/disamb/finite_automata.rs
+++ b/crates/proc/src/disamb/finite_automata.rs
@@ -31,6 +31,8 @@ pub enum EdgeData<O: OutputFormat = Markup> {
 
     /// Not for DFA matching, must be turned into YearSuffix via `RefIR::keep_first_ysh` before DFA construction
     YearSuffixExplicit,
+    /// Not for DFA matching, must be turned into YearSuffix via `RefIR::keep_first_ysh` before DFA construction
+    YearSuffixPlain,
 
     CitationNumber,
     CitationNumberLabel,
@@ -38,6 +40,9 @@ pub enum EdgeData<O: OutputFormat = Markup> {
     // TODO: treat this specially? Does it help you disambiguate back-referencing cites?
     Frnn,
     FrnnLabel,
+
+    /// The accessed date, which should not help disambiguate cites.
+    Accessed,
 }
 
 use std::hash::{Hash, Hasher};

--- a/crates/proc/src/disamb/implementation.rs
+++ b/crates/proc/src/disamb/implementation.rs
@@ -116,9 +116,13 @@ impl Disambiguation<Markup> for Element {
                             return (RefIR::Edge(Some(edge)), GroupVars::Important);
                         }
                     }
-                    if var == StandardVariable::Ordinary(Variable::YearSuffix) && ctx.year_suffix {
-                        let edge = db.edge(EdgeData::YearSuffixExplicit);
-                        return (RefIR::Edge(Some(edge)), GroupVars::Important);
+                    if var == StandardVariable::Ordinary(Variable::YearSuffix) {
+                        if ctx.year_suffix {
+                            let edge = db.edge(EdgeData::YearSuffixExplicit);
+                            return (RefIR::Edge(Some(edge)), GroupVars::Important);
+                        } else {
+                            return (RefIR::Edge(None), GroupVars::Plain);
+                        }
                     }
                     if var == StandardVariable::Number(NumberVariable::FirstReferenceNoteNumber)
                         && ctx.position == Position::Subsequent

--- a/crates/proc/src/disamb/implementation.rs
+++ b/crates/proc/src/disamb/implementation.rs
@@ -143,7 +143,7 @@ impl Disambiguation<Markup> for Element {
                             } else {
                                 state.maybe_suppress_ordinary(v);
                                 ctx.get_ordinary(v, form)
-                                    .map(|val| renderer.text_variable(text, var, val))
+                                    .map(|val| renderer.text_variable(text, var, &val))
                             }
                         }
                         StandardVariable::Number(v) => {

--- a/crates/proc/src/disamb/mod.rs
+++ b/crates/proc/src/disamb/mod.rs
@@ -271,6 +271,7 @@ pub fn create_ref_ir<O: OutputFormat, DB: IrDatabase>(
     let style = db.style();
     let locale = db.locale_by_reference(refr.id.clone());
     let ysh_explicit_edge = db.edge(EdgeData::YearSuffixExplicit);
+    let ysh_plain_edge = db.edge(EdgeData::YearSuffixPlain);
     let ysh_edge = db.edge(EdgeData::YearSuffix);
     let fcs = db.branch_runs();
     let fmt = db.get_formatter();
@@ -301,7 +302,8 @@ pub fn create_ref_ir<O: OutputFormat, DB: IrDatabase>(
                 &mut state,
                 Formatting::default(),
             );
-            ir.keep_first_ysh(ysh_explicit_edge, ysh_edge);
+            ir.keep_first_ysh(ysh_explicit_edge, ysh_plain_edge, ysh_edge);
+            debug!("fc: {:?}, ir: \n{}", fc, ir.debug(db));
             (fc, ir)
         })
         .collect();

--- a/crates/proc/src/disamb/mod.rs
+++ b/crates/proc/src/disamb/mod.rs
@@ -144,14 +144,17 @@ impl<'a, DB: IrDatabase> StyleWalker for FreeCondWalker<'a, DB> {
         sv: StandardVariable,
         _form: VariableForm,
     ) -> Self::Output {
+        let mut implicit_var_test = FreeCondSets::mult_identity();
         if sv.is_independent() {
-            let mut implicit_var_test = FreeCondSets::mult_identity();
             let cond = Cond::Variable((&sv).into());
             implicit_var_test.scalar_multiply_cond(cond, true);
-            implicit_var_test
-        } else {
-            FreeCondSets::mult_identity()
+        } else if sv == StandardVariable::Ordinary(Variable::CitationLabel) {
+            // citation labels typically have a year on the end, so we add year suffixes
+            // to them
+            let cond = Cond::Variable(AnyVariable::Ordinary(Variable::YearSuffix));
+            implicit_var_test.scalar_multiply_cond(cond, true);
         }
+        implicit_var_test
     }
 
     fn date(&mut self, _date: &BodyDate) -> Self::Output {

--- a/crates/proc/src/disamb/names.rs
+++ b/crates/proc/src/disamb/names.rs
@@ -150,10 +150,10 @@ impl Disambiguation<Markup> for Names {
                     }
                 }
             }
-            return (RefIR::Edge(None), GroupVars::OnlyEmpty);
+            return (RefIR::Edge(None), GroupVars::Missing);
         }
 
-        (RefIR::Seq(seq), GroupVars::DidRender)
+        (RefIR::Seq(seq), GroupVars::Important)
     }
 }
 

--- a/crates/proc/src/disamb/ref_context.rs
+++ b/crates/proc/src/disamb/ref_context.rs
@@ -4,6 +4,7 @@ use citeproc_io::output::markup::Markup;
 use citeproc_io::{DateOrRange, NumericValue, Reference};
 use csl::{Name as NameEl, *};
 use std::sync::Arc;
+use std::borrow::Cow;
 
 use crate::disamb::FreeCond;
 
@@ -108,22 +109,31 @@ where
         self.disamb_count = count;
     }
 
-    pub fn get_ordinary(&self, var: Variable, form: VariableForm) -> Option<&str> {
+    pub fn get_ordinary(&self, var: Variable, form: VariableForm) -> Option<Cow<'_, str>> {
         (match (var, form) {
             (Variable::TitleShort, _) | (Variable::Title, VariableForm::Short) => self
                 .reference
                 .ordinary
                 .get(&Variable::TitleShort)
-                .or_else(|| self.reference.ordinary.get(&Variable::Title)),
+                .or_else(|| self.reference.ordinary.get(&Variable::Title))
+                .map(|s| s.as_str())
+                .map(Cow::Borrowed),
             (Variable::ContainerTitleShort, _)
             | (Variable::ContainerTitle, VariableForm::Short) => self
                 .reference
                 .ordinary
                 .get(&Variable::ContainerTitleShort)
-                .or_else(|| self.reference.ordinary.get(&Variable::ContainerTitle)),
-            _ => self.reference.ordinary.get(&var),
+                .or_else(|| self.reference.ordinary.get(&Variable::ContainerTitle))
+                .map(|s| s.as_str())
+                .map(Cow::Borrowed),
+            (Variable::CitationLabel, _) if self.reference.ordinary.get(&var).is_none() => {
+                let tri = crate::citation_label::Trigraph::default();
+                Some(Cow::Owned(tri.make_label(self.reference)))
+            }
+            _ => self.reference.ordinary.get(&var)
+                .map(|s| s.as_str())
+                .map(Cow::Borrowed),
         })
-        .map(|s| s.as_str())
     }
 
     pub fn get_number(&self, var: NumberVariable) -> Option<NumericValue> {
@@ -147,14 +157,14 @@ where
                 NumberVariable::CitationNumber => self.style.bibliography.is_some(),
                 _ => self.get_number(v).is_some(),
             },
-            AnyVariable::Ordinary(v) => {
-                match v {
-                    // TODO: make Hereinafter a FreeCond
-                    Variable::Hereinafter => unimplemented!("Hereinafter as a FreeCond"),
-                    Variable::YearSuffix => self.year_suffix,
-                    _ => self.get_ordinary(v, VariableForm::Long).is_some(),
-                }
-            }
+            AnyVariable::Ordinary(v) => match v {
+                // Generated on demand
+                Variable::CitationLabel => true,
+                // TODO: make Hereinafter a FreeCond
+                Variable::Hereinafter => unimplemented!("Hereinafter as a FreeCond"),
+                Variable::YearSuffix => self.year_suffix,
+                _ => self.get_ordinary(v, VariableForm::Long).is_some(),
+            },
             AnyVariable::Date(v) => self.reference.date.contains_key(&v),
             AnyVariable::Name(v) => self.reference.name.contains_key(&v),
         }

--- a/crates/proc/src/element.rs
+++ b/crates/proc/src/element.rs
@@ -113,7 +113,7 @@ where
                                 } else {
                                     state.maybe_suppress_ordinary(v);
                                     ctx.get_ordinary(v, form)
-                                        .map(|val| renderer.text_variable(text, var, val))
+                                        .map(|val| renderer.text_variable(text, var, &val))
                                 }
                             }
                             StandardVariable::Number(v) => {

--- a/crates/proc/src/group.rs
+++ b/crates/proc/src/group.rs
@@ -13,11 +13,30 @@
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum GroupVars {
     /// A group has only seen stuff like `<text value=""/>` so far
-    NoneSeen,
+    Plain,
+
     /// Renderer encountered >= 1 variables, but did not render any of them
-    OnlyEmpty,
+    Missing,
+
     /// Renderer encountered >= 1 variables that it did render
-    DidRender,
+    Important,
+
+    /// Initial value given to disambiguate="true" conditionals that are initially empty, as their
+    /// content could go either way later, and their currently-empty output shouldn't affect
+    /// whether the surrounding group should render before disambiguation comes around.
+    Unresolved,
+
+    /// For e.g. an explicit `<text variable="year-suffix" />`, which would otherwise cause a
+    /// surrounding group to be Missing initially and be discarded too soon. Just means "don't
+    /// render, but also don't throw it out yet."
+    UnresolvedMissing,
+
+    /// Not instantiated directly; computed value for groups containing only Plain and Unresolved
+    /// children. A group with this overall GV should render as it is 'leaning towards Plain', but
+    /// could still change later.
+    ///
+    /// "Do render this one, but don't rely on it being plain to discard an outer group."
+    UnresolvedPlain,
 }
 
 impl Default for GroupVars {
@@ -31,23 +50,23 @@ use self::GroupVars::*;
 impl GroupVars {
     #[inline]
     pub fn new() -> Self {
-        NoneSeen
+        Plain
     }
 
     #[inline]
     pub fn rendered_if(b: bool) -> Self {
         if b {
-            GroupVars::DidRender
+            GroupVars::Important
         } else {
-            GroupVars::OnlyEmpty
+            GroupVars::Missing
         }
     }
 
     // pub fn with_subtree(self, subtree: Self) -> Self {
     //     match subtree {
-    //         NoneSeen => self,
-    //         OnlyEmpty => self.did_not_render(),
-    //         DidRender => DidRender,
+    //         Plain => self,
+    //         Missing => self.did_not_render(),
+    //         Important => Important,
     //     }
     // }
 
@@ -60,43 +79,78 @@ impl GroupVars {
     /// </group>
     /// ```
     ///
-    /// The tag is `NoneSeen`, the var has `DidRender`.
+    /// The tag is `Plain`, the var has `Important`, so the group is `Important`.
     ///
     /// ```text
-    /// assert_eq!(NoneSeen.neighbour(DidRender), DidRender);
-    /// assert_eq!(NoneSeen.neighbour(OnlyEmpty), OnlyEmpty);
-    /// assert_eq!(DidRender.neighbour(OnlyEmpty), DidRender);
+    /// assert_eq!(Plain.neighbour(Important), Important);
+    /// assert_eq!(Plain.neighbour(Missing), Missing);
+    /// assert_eq!(Important.neighbour(Missing), Important);
     /// ```
     pub fn neighbour(self, other: Self) -> Self {
         match (self, other) {
-            // if either rendered, the parent group did too.
-            (DidRender, _) => DidRender,
-            (_, DidRender) => DidRender,
-            // promote OnlyEmpty
-            (OnlyEmpty, _) => OnlyEmpty,
-            (_, OnlyEmpty) => OnlyEmpty,
-            _ => NoneSeen,
+
+            // if either is Important, the parent group will be too. For sure. Don't need to track
+            // Unresolved any further than this.
+            (Important, _) | (_, Important) => Important,
+
+            // Unresolved + Missing has to stay Unresolved until disambiguation is done
+            (Unresolved, Missing)
+            | (Missing, Unresolved)
+            | (UnresolvedMissing, Missing)
+            | (Missing, UnresolvedMissing)
+            | (UnresolvedMissing, Unresolved)
+            | (Unresolved, UnresolvedMissing)
+            | (Plain, UnresolvedMissing)
+            | (UnresolvedMissing, Plain)
+            | (UnresolvedMissing, UnresolvedMissing)
+            | (UnresolvedMissing, UnresolvedPlain)
+            | (UnresolvedPlain, UnresolvedMissing)
+            | (UnresolvedPlain, Missing)
+            | (Missing, UnresolvedPlain) => UnresolvedMissing,
+
+            (UnresolvedPlain, UnresolvedPlain)
+            | (UnresolvedPlain, Unresolved)
+            | (Unresolved, UnresolvedPlain)
+            | (UnresolvedPlain, Plain)
+            | (Plain, UnresolvedPlain)
+            | (Unresolved, Plain)
+            | (Plain, Unresolved) => UnresolvedPlain,
+
+            // promote Missing over Plain; the style tried and failed to render a variable,
+            // so we must take note of this.
+            (Missing, Missing) | (Missing, Plain) | (Plain, Missing) => Missing,
+
+            (Plain, Plain) => Plain,
+
+            (Unresolved, Unresolved) => Unresolved,
         }
     }
 
     #[inline]
     pub fn should_render_tree(self) -> bool {
-        self != OnlyEmpty
+        self != Missing
     }
 
     #[inline]
     pub fn implicit_conditional<T: Default + PartialEq>(self, ir: T) -> (T, Self) {
         let default = T::default();
         if self.should_render_tree() && ir != default {
-            // "reset" the group vars so that G(NoneSeen, G(OnlyEmpty)) will
-            // render the NoneSeen part. Groups shouldn't look inside inner
+            // "reset" the group vars so that G(Plain, G(Missing)) will
+            // render the Plain part. Groups shouldn't look inside inner
             // groups.
             //
             // https://discourse.citationstyles.org/t/groups-variables-and-missing-dates/1529/18
-            (ir, GroupVars::DidRender)
+            (
+                ir,
+                if self == GroupVars::Unresolved {
+                    self
+                } else {
+                    GroupVars::Important
+                },
+            )
         } else {
-            // Don't render the group! But also don't infect the whole tree with OnlyEmpty.
-            (default, GroupVars::NoneSeen)
+            // Don't render the group! But also don't infect the whole tree with Missing.
+            (default, GroupVars::Plain)
         }
     }
 }

--- a/crates/proc/src/helpers.rs
+++ b/crates/proc/src/helpers.rs
@@ -49,7 +49,7 @@ where
         |(mut acc, acc_gv), (ir, gv)| match ir {
             IR::Rendered(None) => (acc, acc_gv.neighbour(gv)),
             _ => {
-                acc.push(ir);
+                acc.push((ir, gv));
                 (acc, acc_gv.neighbour(gv))
             }
         },

--- a/crates/proc/src/helpers.rs
+++ b/crates/proc/src/helpers.rs
@@ -151,3 +151,20 @@ use fnv::FnvHashSet;
 pub fn fnv_set_with_cap<T: std::hash::Hash + std::cmp::Eq>(cap: usize) -> FnvHashSet<T> {
     FnvHashSet::with_capacity_and_hasher(cap, fnv::FnvBuildHasher::default())
 }
+
+use csl::{Variable, TextElement, StandardVariable, VariableForm, TextCase, TextSource};
+pub fn plain_text_element(v: Variable) -> TextElement {
+    TextElement {
+        source: TextSource::Variable(
+            StandardVariable::Ordinary(v),
+            VariableForm::Long,
+        ),
+        formatting: None,
+        affixes: None,
+        quotes: false,
+        strip_periods: false,
+        text_case: TextCase::None,
+        display: None,
+    }
+}
+

--- a/crates/proc/src/ir.rs
+++ b/crates/proc/src/ir.rs
@@ -9,7 +9,7 @@ use crate::prelude::*;
 use citeproc_io::output::markup::Markup;
 use citeproc_io::output::LocalizedQuotes;
 use csl::Atom;
-use csl::{Affixes, BodyDate, Choose, Element, Formatting, GivenNameDisambiguationRule};
+use csl::{Affixes, Choose, Element, Formatting, GivenNameDisambiguationRule};
 use csl::{NumberVariable, StandardVariable, Variable};
 
 use std::sync::Arc;
@@ -25,8 +25,15 @@ pub enum DisambPass {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+pub struct YearSuffix<O: OutputFormat> {
+    // Clone element into here, because we already know it's a <text variable="" />
+    pub(crate) hook: YearSuffixHook,
+    pub(crate) ir: Box<IR<O>>,
+    pub(crate) group_vars: GroupVars,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum YearSuffixHook {
-    Date(Arc<BodyDate>),
     // Clone element into here, because we already know it's a <text variable="" />
     Explicit(Element),
     Plain,
@@ -219,6 +226,7 @@ use std::sync::Mutex;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ConditionalDisambIR<O: OutputFormat> {
     pub choose: Arc<Choose>,
+    pub group_vars: GroupVars,
     pub done: bool,
     pub ir: Box<IR<O>>,
 }
@@ -235,7 +243,7 @@ pub enum IR<O: OutputFormat = Markup> {
     /// or <choose><if><conditions><condition>
     /// Should also include `if variable="year-suffix"` because that could change.
     ConditionalDisamb(Arc<Mutex<ConditionalDisambIR<O>>>),
-    YearSuffix(YearSuffixHook, Option<O::Build>),
+    YearSuffix(YearSuffix<O>),
 
     // Think:
     // <if disambiguate="true" ...>
@@ -256,9 +264,11 @@ impl<O> IR<O>
 where
     O: OutputFormat,
 {
+    /// Rendered(None), empty YearSuffix or empty seq
     pub fn is_empty(&self) -> bool {
         match self {
-            IR::Rendered(None) | IR::YearSuffix(_, None) => true,
+            IR::Rendered(None) => true,
+            IR::YearSuffix(ys) => ys.ir.is_empty(),
             IR::Seq(seq) if seq.contents.is_empty() => true,
             IR::ConditionalDisamb(c) => c.lock().unwrap().ir.is_empty(),
             IR::Name(nir) => nir.lock().unwrap().ir.is_empty(),
@@ -276,7 +286,7 @@ where
         match (self, other) {
             (IR::Rendered(s), IR::Rendered(o)) if s == o => true,
             (IR::Seq(s), IR::Seq(o)) if s == o => true,
-            (IR::YearSuffix(s1, s2), IR::YearSuffix(o1, o2)) if s1 == o1 && s2 == o2 => true,
+            (IR::YearSuffix(s), IR::YearSuffix(o)) if s == o => true,
             (IR::ConditionalDisamb(a), IR::ConditionalDisamb(b)) => {
                 let aa = a.lock().unwrap();
                 let bb = b.lock().unwrap();
@@ -307,6 +317,8 @@ impl Default for RefIR {
 /// Currently, flattening into EdgeData(String) only works when the Output type is String
 /// So Pandoc isn't ready yet; maybe you can flatten Pandoc structure into a string.
 impl<O: OutputFormat<Output = String>> IR<O> {
+    /// Assumes any group vars have been resolved, so every item touched by flatten should in fact
+    /// be rendered
     pub fn flatten(&self, fmt: &O) -> Option<O::Build> {
         // must clone
         match self {
@@ -314,40 +326,9 @@ impl<O: OutputFormat<Output = String>> IR<O> {
             IR::Rendered(Some(ref x)) => Some(x.inner()),
             IR::Name(nir) => nir.lock().unwrap().ir.flatten(fmt),
             IR::ConditionalDisamb(c) => c.lock().unwrap().ir.flatten(fmt),
-            IR::YearSuffix(_, ref x) => x.clone(),
+            IR::YearSuffix(YearSuffix { ir, .. }) => ir.flatten(fmt),
             IR::Seq(ref seq) => seq.flatten_seq(fmt),
         }
-    }
-}
-
-impl<O: OutputFormat<Output = String>> IrSeq<O> {
-    // TODO: Groupvars
-    fn flatten_seq(&self, fmt: &O) -> Option<O::Build> {
-        let IrSeq {
-            formatting,
-            ref delimiter,
-            ref affixes,
-            ref quotes,
-            display,
-            text_case,
-            ref contents,
-        } = *self;
-        let xs: Vec<_> = contents.iter().filter_map(|i| i.flatten(fmt)).collect();
-        if xs.is_empty() {
-            return None;
-        }
-        let grp = fmt.group(xs, delimiter, formatting);
-        let grp = fmt.affixed_quoted(grp, affixes.as_ref(), quotes.clone());
-        // TODO: pass in_bibliography from ctx
-        let mut grp = fmt.with_display(grp, display, true);
-        fmt.apply_text_case(
-            &mut grp,
-            &IngestOptions {
-                text_case,
-                ..Default::default()
-            },
-        );
-        Some(grp)
     }
 }
 
@@ -387,17 +368,17 @@ impl<O: OutputFormat<Output = String>> CiteEdgeData<O> {
 impl IR<Markup> {
     pub(crate) fn visit_year_suffix_hooks<F>(&mut self, callback: &mut F) -> bool
     where
-        F: (FnMut(&mut IR<Markup>) -> bool),
+        F: (FnMut(&mut YearSuffix<Markup>) -> bool),
     {
         match self {
-            IR::YearSuffix(..) => callback(self),
+            IR::YearSuffix(ys) => callback(ys),
             IR::ConditionalDisamb(c) => {
                 // XXX(check this): boxed has already been rendered, so the `if` was with
                 // disambiguate=false, probably. So you can visit it.
                 c.lock().unwrap().ir.visit_year_suffix_hooks(callback)
             }
             IR::Seq(seq) => {
-                for ir in seq.contents.iter_mut() {
+                for (ir, gv) in seq.contents.iter_mut() {
                     let done = ir.visit_year_suffix_hooks(callback);
                     if done {
                         return true;
@@ -408,7 +389,9 @@ impl IR<Markup> {
             _ => false,
         }
     }
+}
 
+impl IR<Markup> {
     fn append_edges(
         &self,
         edges: &mut Vec<EdgeData>,
@@ -420,17 +403,8 @@ impl IR<Markup> {
             IR::Rendered(Some(ed)) => {
                 edges.push(ed.to_edge_data(fmt, formatting))
             }
-            // TODO: reshape year suffixes to contain IR with maybe a CiteEdgeData::YearSuffix
-            // inside
-            IR::YearSuffix(_hook, x) => {
-                let out = x
-                    .as_ref()
-                    .map(|x| fmt.output_in_context(x.clone(), formatting, None));
-                if let Some(o) = out {
-                    if !o.is_empty() {
-                        edges.push(EdgeData::Output(o))
-                    }
-                }
+            IR::YearSuffix(ys) => {
+                ys.ir.append_edges(edges, fmt, formatting)
             }
             IR::ConditionalDisamb(c) => c.lock().unwrap().ir.append_edges(edges, fmt, formatting),
             IR::Seq(seq) => seq.append_edges(edges, fmt, formatting),
@@ -457,15 +431,97 @@ impl IR<Markup> {
 //     }
 // }
 
+/// # Disambiguation and group_vars
+///
+/// IrSeq needs to hold things 
 #[derive(Default, Debug, PartialEq, Eq, Clone)]
 pub struct IrSeq<O: OutputFormat> {
-    pub contents: Vec<IR<O>>,
+    pub contents: Vec<IrSum<O>>,
     pub formatting: Option<Formatting>,
     pub affixes: Option<Affixes>,
     pub delimiter: Atom,
     pub display: Option<DisplayMode>,
     pub quotes: Option<LocalizedQuotes>,
     pub text_case: TextCase,
+}
+
+
+impl<O: OutputFormat> IR<O> {
+    pub(crate) fn recompute_group_vars(&mut self) {
+        match self {
+            IR::Seq(seq) => seq.recompute_group_vars(),
+            _ => {},
+        }
+    }
+}
+
+impl<O: OutputFormat> IrSeq<O> {
+    pub(crate) fn overall_group_vars(&self) -> GroupVars {
+        self.contents.iter().fold(GroupVars::new(), |acc, (_, gv)| acc.neighbour(*gv))
+    }
+    /// GVs are stored outside of individual child IRs, so we need a way to update those if the
+    /// children have mutated themselves.
+    pub(crate) fn recompute_group_vars(&mut self) {
+        for (ir, gv) in self.contents.iter_mut() {
+            if let Some(force_gv) = ir.force_gv() {
+                *gv = force_gv;
+            }
+        }
+    }
+}
+
+impl<O> IR<O>
+where
+    O: OutputFormat,
+{
+    pub(crate) fn force_gv(&mut self) -> Option<GroupVars> {
+        match self {
+            IR::Rendered(x) => None,
+            IR::YearSuffix(ys) => Some(ys.group_vars),
+            IR::Seq(seq) => {
+                seq.recompute_group_vars();
+                Some(seq.overall_group_vars())
+            },
+            IR::ConditionalDisamb(c) => Some(c.lock().unwrap().group_vars),
+            IR::Name(nir) => None,
+        }
+    }
+}
+
+impl<O: OutputFormat<Output = String>> IrSeq<O> {
+    // TODO: Groupvars
+    fn flatten_seq(&self, fmt: &O) -> Option<O::Build> {
+        // Do this where it won't require mut access
+        // self.recompute_group_vars();
+        if !self.overall_group_vars().should_render_tree() {
+            return None;
+        }
+        let IrSeq {
+            formatting,
+            ref delimiter,
+            ref affixes,
+            ref quotes,
+            display,
+            text_case,
+            ref contents,
+        } = *self;
+        let xs: Vec<_> = contents.iter().filter_map(|(ir, gv)| ir.flatten(fmt)).collect();
+        if xs.is_empty() {
+            return None;
+        }
+        let grp = fmt.group(xs, delimiter, formatting);
+        let grp = fmt.affixed_quoted(grp, affixes.as_ref(), quotes.clone());
+        // TODO: pass in_bibliography from ctx
+        let mut grp = fmt.with_display(grp, display, true);
+        fmt.apply_text_case(
+            &mut grp,
+            &IngestOptions {
+                text_case,
+                ..Default::default()
+            },
+        );
+        Some(grp)
+    }
 }
 
 impl IrSeq<Markup> {
@@ -511,7 +567,7 @@ impl IrSeq<Markup> {
         let _len = contents.len();
         let mut seen = false;
         let mut sub = Vec::new();
-        for (_n, ir) in contents.iter().enumerate() {
+        for (_n, (ir, _gv)) in contents.iter().enumerate() {
             ir.append_edges(&mut sub, fmt, sub_formatting);
             if !sub.is_empty() {
                 if seen {

--- a/crates/proc/src/ir.rs
+++ b/crates/proc/src/ir.rs
@@ -9,7 +9,7 @@ use crate::prelude::*;
 use citeproc_io::output::markup::Markup;
 use citeproc_io::output::LocalizedQuotes;
 use csl::Atom;
-use csl::{Affixes, Choose, Element, Formatting, GivenNameDisambiguationRule, DateVariable};
+use csl::{Affixes, Choose, Element, Formatting, GivenNameDisambiguationRule, DateVariable, TextElement};
 use csl::{NumberVariable, StandardVariable, Variable};
 
 use std::sync::Arc;
@@ -32,10 +32,23 @@ pub struct YearSuffix<O: OutputFormat> {
     pub(crate) group_vars: GroupVars,
 }
 
+impl<O: OutputFormat> IR<O> {
+    pub(crate) fn year_suffix(hook: YearSuffixHook) -> IrSum<O> {
+        (
+            IR::YearSuffix(YearSuffix {
+                hook,
+                group_vars: GroupVars::Unresolved,
+                ir: Box::new(IR::Rendered(None)),
+            }),
+            GroupVars::Unresolved
+        )
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum YearSuffixHook {
     // Clone element into here, because we already know it's a <text variable="" />
-    Explicit(Element),
+    Explicit(TextElement),
     Plain,
 }
 

--- a/crates/proc/src/lib.rs
+++ b/crates/proc/src/lib.rs
@@ -16,6 +16,7 @@ use csl::Atom;
 use std::collections::HashSet;
 
 mod choose;
+mod citation_label;
 mod cite_context;
 mod date;
 pub mod db;

--- a/crates/proc/src/lib.rs
+++ b/crates/proc/src/lib.rs
@@ -273,9 +273,15 @@ impl IrState {
         }
     }
 
-    pub fn maybe_suppress_date(&mut self, var: DateVariable) {
-        if self.name_override.in_substitute {
-            self.suppressed.insert(AnyVariable::Date(var));
+    #[inline]
+    pub fn maybe_suppress_date<T: Default>(&mut self, var: DateVariable, f: impl Fn(&mut Self) -> T) -> T {
+        if self.is_suppressed_date(var) {
+            Default::default()
+        } else {
+            if self.name_override.in_substitute {
+                self.suppressed.insert(AnyVariable::Date(var));
+            }
+            f(self)
         }
     }
 

--- a/crates/proc/src/sort.rs
+++ b/crates/proc/src/sort.rs
@@ -452,7 +452,7 @@ impl<'a, DB: IrDatabase, O: OutputFormat> StyleWalker for SortingWalker<'a, DB, 
     //     3. Return count as a {:08} padded number
 
     fn names(&mut self, names: &Names) -> Self::Output {
-        let (mut ir, gv) = crate::names::intermediate(names, self.db, &mut self.state, &self.ctx);
+        let (ir, gv) = crate::names::intermediate(names, self.db, &mut self.state, &self.ctx);
         (ir.flatten(&self.ctx.format).unwrap_or_default(), gv)
     }
 
@@ -460,7 +460,7 @@ impl<'a, DB: IrDatabase, O: OutputFormat> StyleWalker for SortingWalker<'a, DB, 
     // interpreted as a number, and the rest can still be a string. Hence CmpDate below.
     //
     fn date(&mut self, date: &BodyDate) -> Self::Output {
-        let (mut ir, gv) = date.intermediate(self.db, &mut self.state, &self.ctx);
+        let (ir, gv) = date.intermediate(self.db, &mut self.state, &self.ctx);
         (ir.flatten(&self.ctx.format).unwrap_or_default(), gv)
     }
 

--- a/crates/proc/src/sort.rs
+++ b/crates/proc/src/sort.rs
@@ -452,7 +452,7 @@ impl<'a, DB: IrDatabase, O: OutputFormat> StyleWalker for SortingWalker<'a, DB, 
     //     3. Return count as a {:08} padded number
 
     fn names(&mut self, names: &Names) -> Self::Output {
-        let (ir, gv) = crate::names::intermediate(names, self.db, &mut self.state, &self.ctx);
+        let (mut ir, gv) = crate::names::intermediate(names, self.db, &mut self.state, &self.ctx);
         (ir.flatten(&self.ctx.format).unwrap_or_default(), gv)
     }
 
@@ -460,7 +460,7 @@ impl<'a, DB: IrDatabase, O: OutputFormat> StyleWalker for SortingWalker<'a, DB, 
     // interpreted as a number, and the rest can still be a string. Hence CmpDate below.
     //
     fn date(&mut self, date: &BodyDate) -> Self::Output {
-        let (ir, gv) = date.intermediate(self.db, &mut self.state, &self.ctx);
+        let (mut ir, gv) = date.intermediate(self.db, &mut self.state, &self.ctx);
         (ir.flatten(&self.ctx.format).unwrap_or_default(), gv)
     }
 

--- a/crates/proc/src/sort.rs
+++ b/crates/proc/src/sort.rs
@@ -395,7 +395,7 @@ impl<'a, DB: IrDatabase, O: OutputFormat> StyleWalker for SortingWalker<'a, DB, 
             StandardVariable::Ordinary(var) => self
                 .ctx
                 .get_ordinary(var, form)
-                .map(|val| renderer.text_variable(text, svar, val)),
+                .map(|val| renderer.text_variable(text, svar, &val)),
         };
         let gv = GroupVars::rendered_if(res.is_some());
         (res.unwrap_or_default(), gv)

--- a/crates/tools/src/bin/inspect.rs
+++ b/crates/tools/src/bin/inspect.rs
@@ -42,7 +42,7 @@ struct Inspect {
 
 fn main() -> Result<(), Error> {
     use env_logger::Env;
-    env_logger::from_env(Env::default().default_filter_or("citeproc_proc=debug,citeproc_io=debug,citeproc_db=debug")).init();
+    env_logger::from_env(Env::default().default_filter_or("citeproc_proc=debug,citeproc_io=debug,citeproc_db=debug,citeproc_io::output::markup::move_punctuation=warn")).init();
     let opt = Inspect::from_args();
     let mut path = workspace_root();
     path.push("crates");


### PR DESCRIPTION
PR implements citation-label, with a parser for on the citeproc-js
'trigraph' option format string, and the same default.

See https://discourse.citationstyles.org/t/citation-label-formatting/1585/5

Some changes were necessary to pass the disambiguation tests that use
citation labels, like `Fred1995a, Fred1995b`.

Citation labels get an implicit year-suffix variable placed after
them, the same way a date's year get one.

Incidentally, to deal with explicit citation labels within groups being
initially `Missing` for the implicit conditionals which have only plain
text beside them, those groups have to retain knowledge of their
children's GroupVars even after the initial render, and recompute it
when the year-suffix node gets a value and becomes `Important` later on.
That was a long time coming, but it is done here.