### PR TITLE
Miscellaneous punctuation

### DIFF
--- a/crates/citeproc/tests/data/snapshot.txt
+++ b/crates/citeproc/tests/data/snapshot.txt
@@ -58,3 +58,9 @@ label_EditorTranslator1.txt
 # citeproc-js chooses to parse rich text in numeric fields. The test hasn't #
 # decided this is wrong.
 flipflop_NumericField.txt
+
+# Test implies i.e. month = 17 means Spring, implying 17-20 are also valid seasons,
+# i.e. if month > 12 && month < 25 { season = (month - 12) % 4 }
+# There is no reason for this to be the case. There's CSL-JSON's 13..=16 range,
+# and also EDTF's 21..=24 range, but no usage of the range in between.
+date_VariousInvalidDates.txt

--- a/crates/citeproc/tests/data/snapshot.txt
+++ b/crates/citeproc/tests/data/snapshot.txt
@@ -54,3 +54,7 @@ position_IbidInText.txt
 # title has already been rendered. citeproc-rs gets the editortranslator label
 # right though.
 label_EditorTranslator1.txt
+
+# citeproc-js chooses to parse rich text in numeric fields. The test hasn't #
+# decided this is wrong.
+flipflop_NumericField.txt

--- a/crates/citeproc/tests/snapshots/suite__date_VariousInvalidDates.txt.snap
+++ b/crates/citeproc/tests/snapshots/suite__date_VariousInvalidDates.txt.snap
@@ -1,0 +1,5 @@
+---
+source: crates/citeproc/tests/suite.rs
+expression: res
+---
+Date: (); Date: (Spring); Date: (); Date: (); Date: (Winter)

--- a/crates/citeproc/tests/snapshots/suite__flipflop_NumericField.txt.snap
+++ b/crates/citeproc/tests/snapshots/suite__flipflop_NumericField.txt.snap
@@ -1,0 +1,5 @@
+---
+source: crates/citeproc/tests/suite.rs
+expression: res
+---
+1<sup>er</sup>

--- a/crates/io/src/lib.rs
+++ b/crates/io/src/lib.rs
@@ -544,6 +544,7 @@ impl IngestOptions {
                 MicroNode::Formatted(children, FormatCmd::VerticalAlignmentSuperscript)
                 | MicroNode::Formatted(children, FormatCmd::FontVariantSmallCaps)
                 | MicroNode::Formatted(children, FormatCmd::VerticalAlignmentSubscript)
+                | MicroNode::NoDecor(children)
                 | MicroNode::NoCase(children) => {
                     seen_one = seen_one || self.contains_word_micro(children.as_ref());
                 }
@@ -622,6 +623,7 @@ fn any_micros<F: Fn(&str) -> bool + Copy>(f: F, invert: bool, micros: &[MicroNod
         MicroNode::Text(txt) => f(txt.as_ref()),
         MicroNode::Formatted(children, _)
         | MicroNode::Quoted { children, .. }
+        | MicroNode::NoDecor(children)
         | MicroNode::NoCase(children) => any_micros(f, invert, children) ^ invert,
     }) ^ invert
 }

--- a/crates/io/src/lib.rs
+++ b/crates/io/src/lib.rs
@@ -25,6 +25,7 @@ mod cite;
 mod csl_json;
 mod date;
 mod names;
+pub use names::TrimInPlace;
 mod numeric;
 pub mod output;
 mod reference;

--- a/crates/io/src/names.rs
+++ b/crates/io/src/names.rs
@@ -46,8 +46,8 @@ macro_rules! regex {
 use std::borrow::Cow;
 
 fn split_particles(mut orig_name_str: &str, is_given: bool) -> Option<(String, String)> {
-    let givenn_particles_re = regex!("^(?:\u{02bb} |\u{2019} | |\' )?\\S+ *");
-    let family_particles_re = regex!("^\\S+(?:\\-|\u{02bb}|\u{2019}| |\') *");
+    let givenn_particles_re = regex!("^(?:\u{02bb}\\s|\u{2019}\\s|\\s|'\\s)?\\S+\\s*");
+    let family_particles_re = regex!("^\\S+(?:\\-|\u{02bb}|\u{2019}|\\s|\')\\s*");
     debug!("split_particles: {:?}", orig_name_str);
     let (splitter, name_str) = if is_given {
         (givenn_particles_re, Cow::Owned(orig_name_str.chars().rev().collect()))

--- a/crates/io/src/names.rs
+++ b/crates/io/src/names.rs
@@ -280,7 +280,11 @@ fn parse_particles() {
 }
 
 /// https://users.rust-lang.org/t/trim-string-in-place/15809/8
-trait TrimInPlace { fn trim_in_place (self: &'_ mut Self); }
+pub trait TrimInPlace {
+    fn trim_in_place (self: &'_ mut Self);
+    fn trim_start_in_place (self: &'_ mut Self);
+    fn trim_end_in_place (self: &'_ mut Self);
+}
 impl TrimInPlace for String {
     fn trim_in_place (self: &'_ mut Self)
     {
@@ -296,6 +300,25 @@ impl TrimInPlace for String {
             );
         }
         self.truncate(len); // no String::set_len() in std ...
+    }
+    fn trim_start_in_place (self: &'_ mut Self)
+    {
+        let (start, len): (*const u8, usize) = {
+            let self_trimmed: &str = self.trim_start();
+            (self_trimmed.as_ptr(), self_trimmed.len())
+        };
+        unsafe {
+            core::ptr::copy(
+                start,
+                self.as_bytes_mut().as_mut_ptr(), // no str::as_mut_ptr() in std ...
+                len,
+            );
+        }
+        self.truncate(len); // no String::set_len() in std ...
+    }
+    fn trim_end_in_place (self: &'_ mut Self)
+    {
+        self.truncate(self.trim_end().len());
     }
 }
 

--- a/crates/io/src/numeric.rs
+++ b/crates/io/src/numeric.rs
@@ -303,7 +303,8 @@ impl<'a> NumericValue<'a> {
     }
     pub fn from_localized(and_term: &'a str) -> impl Fn(&'a NumberLike) -> NumericValue<'a> + 'a {
         move |like| match like {
-            NumberLike::Str(input) => NumericValue::parse_full(input, and_term),
+            // locator_WithLeadingSpace
+            NumberLike::Str(input) => NumericValue::parse_full(input.trim(), and_term),
             NumberLike::Num(n) => NumericValue::num(*n),
         }
     }

--- a/crates/io/src/output/markup.rs
+++ b/crates/io/src/output/markup.rs
@@ -27,6 +27,8 @@ use self::flip_flop::FlipFlopState;
 mod move_punctuation;
 mod parse_quotes;
 use self::move_punctuation::move_punctuation;
+
+pub use self::move_punctuation::is_punc;
 pub use self::parse_quotes::parse_quotes;
 pub(self) mod puncttable;
 

--- a/crates/io/src/output/markup/flip_flop.rs
+++ b/crates/io/src/output/markup/flip_flop.rs
@@ -7,72 +7,95 @@
 use super::InlineElement;
 use crate::output::micro_html::MicroNode;
 use crate::output::FormatCmd;
-use csl::{FontStyle, FontVariant, FontWeight, Formatting};
+use csl::{FontStyle, FontVariant, FontWeight, Formatting, TextDecoration, VerticalAlignment};
 
-#[derive(Default, Debug, Copy, Clone)]
+#[derive(Default, Debug, Copy, Clone, PartialEq)]
 pub struct FlipFlopState {
-    in_emph: bool,
-    emph: FontStyle,
-    in_strong: bool,
-    in_small_caps: bool,
     in_inner_quotes: bool,
+    font_style: FontStyle,
+    text_decoration: TextDecoration,
+    font_weight: FontWeight,
+    font_variant: FontVariant,
+    vertical_alignment: VerticalAlignment,
 }
 
 impl FlipFlopState {
     pub fn from_formatting(f: Formatting) -> Self {
         FlipFlopState {
-            emph: f.font_style.unwrap_or_default(),
-            in_emph: f.font_style == Some(FontStyle::Italic)
-                || f.font_style == Some(FontStyle::Oblique),
-            in_strong: f.font_weight == Some(FontWeight::Bold),
-            in_small_caps: f.font_variant == Some(FontVariant::SmallCaps),
             in_inner_quotes: false,
+            font_weight: f.font_weight.unwrap_or_default(),
+            font_style: f.font_style.unwrap_or_default(),
+            font_variant: f.font_variant.unwrap_or_default(),
+            text_decoration: f.text_decoration.unwrap_or_default(),
+            vertical_alignment: f.vertical_alignment.unwrap_or_default(),
         }
     }
     pub fn flip_flop_inlines(&self, inlines: &[InlineElement]) -> Vec<InlineElement> {
+        let mut new = Vec::with_capacity(inlines.len());
         inlines
             .iter()
-            .filter_map(|inl| flip_flop(inl, self))
-            .collect()
+            .for_each(|inl| match flip_flop(inl, self) {
+                Ok(x) => new.push(x),
+                Err(vec) => new.extend(vec.into_iter()),
+            });
+        new
+    }
+    /// Retval is whether any change resulted
+    pub fn push_cmd(&mut self, cmd: FormatCmd) -> bool {
+        let old = self.clone();
+        match cmd {
+            FormatCmd::FontStyleItalic => self.font_style = FontStyle::Italic,
+            FormatCmd::FontStyleOblique => self.font_style = FontStyle::Oblique,
+            FormatCmd::FontStyleNormal => self.font_style = FontStyle::Normal,
+            FormatCmd::FontWeightBold => self.font_weight = FontWeight::Bold,
+            FormatCmd::FontWeightNormal => self.font_weight = FontWeight::Normal,
+            FormatCmd::FontWeightLight => self.font_weight = FontWeight::Light,
+            FormatCmd::FontVariantSmallCaps => self.font_variant = FontVariant::SmallCaps,
+            FormatCmd::FontVariantNormal => self.font_variant  = FontVariant::Normal,
+            FormatCmd::TextDecorationUnderline => self.text_decoration = TextDecoration::Underline,
+            FormatCmd::TextDecorationNone => self.text_decoration = TextDecoration::None,
+            FormatCmd::VerticalAlignmentSuperscript => self.vertical_alignment = VerticalAlignment::Superscript,
+            FormatCmd::VerticalAlignmentSubscript => self.vertical_alignment = VerticalAlignment::Subscript,
+            FormatCmd::VerticalAlignmentBaseline => self.vertical_alignment = VerticalAlignment::Baseline,
+            _ => return false,
+            // FormatCmd::DisplayBlock,
+            // FormatCmd::DisplayIndent,
+            // FormatCmd::DisplayLeftMargin,
+            // FormatCmd::DisplayRightInline,
+        }
+        *self != old
     }
 }
 
-fn flip_flop(inline: &InlineElement, state: &FlipFlopState) -> Option<InlineElement> {
+fn flip_flop(inline: &InlineElement, state: &FlipFlopState) -> Result<InlineElement, Vec<InlineElement>> {
     match *inline {
         InlineElement::Micro(ref nodes) => {
-            let subs = flip_flop_nodes(nodes, state);
-            Some(InlineElement::Micro(subs))
+            let nodes = flip_flop_nodes(nodes, state);
+            Ok(InlineElement::Micro(nodes))
         }
         InlineElement::Formatted(ref ils, f) => {
             let mut flop = state.clone();
             let mut new_f = f;
             if let Some(fs) = f.font_style {
-                let samey = fs == state.emph;
-                if samey {
+                if fs == state.font_style {
                     new_f.font_style = None;
                 }
-                flop.in_emph = match fs {
-                    FontStyle::Italic | FontStyle::Oblique => true,
-                    _ => false,
-                };
-                flop.emph = fs;
+                flop.font_style = fs;
             }
             if let Some(fw) = f.font_weight {
-                let want = fw == FontWeight::Bold;
-                if flop.in_strong == want && want {
+                if fw == state.font_weight {
                     new_f.font_weight = None;
                 }
-                flop.in_strong = want;
+                flop.font_weight = fw;
             }
             if let Some(fv) = f.font_variant {
-                let want_small_caps = fv == FontVariant::SmallCaps;
-                if flop.in_small_caps == want_small_caps {
+                if fv == state.font_variant {
                     new_f.font_variant = None;
                 }
-                flop.in_small_caps = want_small_caps;
+                flop.font_variant = fv;
             }
-            let subs = flop.flip_flop_inlines(ils);
-            Some(InlineElement::Formatted(subs, new_f))
+            let nodes = flop.flip_flop_inlines(ils);
+            Ok(InlineElement::Formatted(nodes, new_f))
         }
 
         InlineElement::Quoted {
@@ -82,11 +105,11 @@ fn flip_flop(inline: &InlineElement, state: &FlipFlopState) -> Option<InlineElem
         } => {
             let mut flop = state.clone();
             flop.in_inner_quotes = !flop.in_inner_quotes;
-            let subs = flop.flip_flop_inlines(inlines);
-            Some(InlineElement::Quoted {
+            let nodes = flop.flip_flop_inlines(inlines);
+            Ok(InlineElement::Quoted {
                 is_inner: flop.in_inner_quotes,
                 localized: localized.clone(),
-                inlines: subs,
+                inlines: nodes,
             })
         }
 
@@ -95,34 +118,38 @@ fn flip_flop(inline: &InlineElement, state: &FlipFlopState) -> Option<InlineElem
             ref url,
             ref content,
         } => {
-            let subs = state.flip_flop_inlines(content);
-            Some(InlineElement::Anchor {
+            let nodes = state.flip_flop_inlines(content);
+            Ok(InlineElement::Anchor {
                 title: title.clone(),
                 url: url.clone(),
-                content: subs,
+                content: nodes,
             })
         }
 
         InlineElement::Div(dm, ref inlines) => {
-            let subs = state.flip_flop_inlines(inlines);
-            Some(InlineElement::Div(dm, subs))
+            let nodes = state.flip_flop_inlines(inlines);
+            Ok(InlineElement::Div(dm, nodes))
         }
 
-        InlineElement::Text(ref string) if string.is_empty() => None,
+        InlineElement::Text(ref string) if string.is_empty() => Err(vec![]),
 
-        _ => Some(inline.clone()),
+        _ => Ok(inline.clone()),
     }
 
     // a => a
 }
 fn flip_flop_nodes(nodes: &[MicroNode], state: &FlipFlopState) -> Vec<MicroNode> {
+    let mut new = Vec::with_capacity(nodes.len());
     nodes
         .iter()
-        .map(|nod| flip_flop_node(nod, state).unwrap_or_else(|| nod.clone()))
-        .collect()
+        .for_each(|node| match flip_flop_node(node, state) {
+            Ok(x) => new.push(x),
+            Err(vec) => new.extend(vec.into_iter()),
+        });
+    new
 }
 
-fn flip_flop_node(node: &MicroNode, state: &FlipFlopState) -> Option<MicroNode> {
+fn flip_flop_node(node: &MicroNode, state: &FlipFlopState) -> Result<MicroNode, Vec<MicroNode>> {
     match node {
         MicroNode::Quoted {
             ref children,
@@ -131,54 +158,106 @@ fn flip_flop_node(node: &MicroNode, state: &FlipFlopState) -> Option<MicroNode> 
         } => {
             let mut flop = state.clone();
             flop.in_inner_quotes = !state.in_inner_quotes;
-            let subs = flip_flop_nodes(children, &flop);
-            Some(MicroNode::Quoted {
+            let nodes = flip_flop_nodes(children, &flop);
+            Ok(MicroNode::Quoted {
                 is_inner: flop.in_inner_quotes,
                 localized: localized.clone(),
-                children: subs,
+                children: nodes,
             })
         }
         MicroNode::Formatted(ref nodes, cmd) => {
             let mut flop = state.clone();
             match cmd {
-                FormatCmd::FontStyleItalic => {
-                    flop.in_emph = !flop.in_emph;
-                    let subs = flip_flop_nodes(nodes, &flop);
-                    if state.in_emph {
-                        Some(MicroNode::Formatted(subs, FormatCmd::FontStyleNormal))
+                FormatCmd::FontStyleItalic | FormatCmd::FontStyleNormal | FormatCmd::FontStyleOblique => {
+                    let is_italic = |x| x != FontStyle::Normal;
+                    let outer = state.font_style;
+                    flop.push_cmd(*cmd);
+                    let inner = flop.font_style;
+                    if is_italic(outer) && is_italic(inner) {
+                        flop.font_style = FontStyle::Normal;
+                        let nodes = flip_flop_nodes(nodes, &flop);
+                        Ok(MicroNode::Formatted(nodes, FormatCmd::FontStyleNormal))
+                    } else if outer == inner {
+                        let nodes = flip_flop_nodes(nodes, &flop);
+                        Err(nodes)
                     } else {
-                        Some(MicroNode::Formatted(subs, *cmd))
+                        let nodes = flip_flop_nodes(nodes, &flop);
+                        Ok(MicroNode::Formatted(nodes, *cmd))
                     }
                 }
-                FormatCmd::FontWeightBold => {
-                    flop.in_strong = !flop.in_strong;
-                    let subs = flip_flop_nodes(nodes, &flop);
-                    if state.in_strong {
-                        Some(MicroNode::Formatted(subs, FormatCmd::FontWeightNormal))
+                FormatCmd::FontWeightBold | FormatCmd::FontWeightLight | FormatCmd::FontWeightNormal => {
+                    let outer = state.font_weight;
+                    flop.push_cmd(*cmd);
+                    let inner = flop.font_weight;
+                    if outer == inner && inner != FontWeight::Normal {
+                        flop.font_style = FontStyle::Normal;
+                        let nodes = flip_flop_nodes(nodes, &flop);
+                        Ok(MicroNode::Formatted(nodes, FormatCmd::FontWeightNormal))
+                    } else if outer == inner {
+                        let nodes = flip_flop_nodes(nodes, &flop);
+                        Err(nodes)
                     } else {
-                        Some(MicroNode::Formatted(subs, *cmd))
+                        let nodes = flip_flop_nodes(nodes, &flop);
+                        Ok(MicroNode::Formatted(nodes, *cmd))
                     }
                 }
-                FormatCmd::FontVariantSmallCaps => {
-                    flop.in_small_caps = !flop.in_small_caps;
-                    let subs = flip_flop_nodes(nodes, &flop);
-                    if state.in_small_caps {
-                        Some(MicroNode::Formatted(subs, FormatCmd::FontVariantNormal))
+                FormatCmd::FontVariantSmallCaps | FormatCmd::FontVariantNormal => {
+                    let outer = state.font_variant;
+                    flop.push_cmd(*cmd);
+                    let inner = flop.font_variant;
+                    if outer == inner && inner != FontVariant::Normal {
+                        flop.font_variant = FontVariant::Normal;
+                        let nodes = flip_flop_nodes(nodes, &flop);
+                        Ok(MicroNode::Formatted(nodes, FormatCmd::FontVariantNormal))
+                    } else if outer == inner {
+                        let nodes = flip_flop_nodes(nodes, &flop);
+                        Err(nodes)
                     } else {
-                        Some(MicroNode::Formatted(subs, *cmd))
+                        let nodes = flip_flop_nodes(nodes, &flop);
+                        Ok(MicroNode::Formatted(nodes, *cmd))
                     }
                 }
                 // i.e. sup and sub
                 _ => {
-                    let subs = flip_flop_nodes(nodes, state);
-                    Some(MicroNode::Formatted(subs, *cmd))
+                    let nodes = flip_flop_nodes(nodes, state);
+                    Ok(MicroNode::Formatted(nodes, *cmd))
                 }
             }
         }
-        MicroNode::Text(_) => None,
+        MicroNode::Text(_) => Ok(node.clone()),
         MicroNode::NoCase(ref nodes) => {
-            let subs = flip_flop_nodes(nodes, state);
-            Some(MicroNode::NoCase(subs))
+            let nodes = flip_flop_nodes(nodes, state);
+            Ok(MicroNode::NoCase(nodes))
         }
+        MicroNode::NoDecor(ref nodes) => {
+            let mut flop = state.clone();
+            flop.font_style = FontStyle::Normal;
+            let fs = state.font_style == flop.font_style;
+            flop.font_weight = FontWeight::Normal;
+            let fw = state.font_weight == flop.font_weight;
+            flop.font_variant = FontVariant::Normal;
+            let fv = state.font_variant == flop.font_variant;
+            flop.text_decoration = TextDecoration::None;
+            let td = state.text_decoration == flop.text_decoration;
+            let nodes = flip_flop_nodes(nodes, &flop);
+            if fs && fw && fv && td {
+                Err(nodes)
+            } else {
+                let mut out = nodes;
+                if !fs {
+                    out = vec![MicroNode::Formatted(out, FormatCmd::FontStyleNormal)]
+                }
+                if !fw {
+                    out = vec![MicroNode::Formatted(out, FormatCmd::FontWeightNormal)]
+                }
+                if !fv {
+                    out = vec![MicroNode::Formatted(out, FormatCmd::FontVariantNormal)]
+                }
+                if !td {
+                    out = vec![MicroNode::Formatted(out, FormatCmd::TextDecorationNone)]
+                }
+                Err(out)
+            }
+        },
     }
 }

--- a/crates/io/src/output/markup/html.rs
+++ b/crates/io/src/output/markup/html.rs
@@ -95,6 +95,9 @@ impl<'a> MarkupWriter for HtmlWriter<'a> {
             NoCase(inners) => {
                 self.write_micros(inners);
             }
+            NoDecor(inners) => {
+                self.write_micros(inners);
+            }
         }
     }
 

--- a/crates/io/src/output/markup/move_punctuation.rs
+++ b/crates/io/src/output/markup/move_punctuation.rs
@@ -26,7 +26,7 @@ fn smash_string_push(base: &mut String, mut suff: &str) {
         suff = suff_trimmed;
         let trimmed = base.trim_end();
         if trimmed.chars().rev().nth(0).map_or(false, is_punc) {
-            base.truncate(trimmed.len())
+            base.truncate(trimmed.len());
         }
     }
     let base_len = base.len();

--- a/crates/io/src/output/markup/move_punctuation.rs
+++ b/crates/io/src/output/markup/move_punctuation.rs
@@ -378,7 +378,7 @@ enum Where {
     Split(char, char),
 }
 
-fn is_punc(c: char) -> bool {
+pub fn is_punc(c: char) -> bool {
     c == '.' || c == ',' || c == '!' || c == '?' || c == ';' || c == ':'
 }
 

--- a/crates/io/src/output/markup/move_punctuation.rs
+++ b/crates/io/src/output/markup/move_punctuation.rs
@@ -46,6 +46,39 @@ fn smash_string_push(base: &mut String, mut suff: &str) {
     }
 }
 
+fn smash_just_punc(base: &mut String, suff: &mut String) {
+    info!("smash_just_punc {:?} <- {:?}", base, suff);
+    let mut suff_append: &str = suff.as_ref();
+    let suff_trimmed = suff_append.trim_start();
+    if base.trim_end().chars().rev().nth(0).map_or(false, is_punc)
+        && suff_trimmed.chars().nth(0).map_or(false, is_punc)
+    {
+        suff_append = suff_trimmed;
+        let trimmed = base.trim_end();
+        if trimmed.chars().rev().nth(0).map_or(false, is_punc) {
+            base.truncate(trimmed.len())
+        }
+    }
+    let base_len = base.len();
+    let suff_len = suff.len();
+    let last_width = base.chars().rev().nth(0).map_or(0, |x| x.len_utf8());
+    let first_width = suff.chars().nth(0).map_or(0, |x| x.len_utf8());
+    let width = last_width + first_width;
+    base.push_str(&suff[..first_width]);
+    // Smash across the boundary
+    if base_len > 0 && suff_len > 0 {
+        let start = base_len - last_width;
+        let range = start .. start + width;
+        if let Some(Some(replacement)) = FULL_MONTY_PLAIN.get(&base.as_bytes()[range.clone()]) {
+            info!("smash_just_punc REPLACING {:?} with {:?}", &base[range.clone()], *replacement);
+            base.replace_range(range, *replacement);
+            suff.replace_range(..first_width, "");
+        } else {
+            base.truncate(base_len);
+        }
+    }
+}
+
 impl InlineElement {
     // If returns Some, insert the string before the micro.
     fn normalise_micro_single_text(&mut self) -> Option<Vec<InlineElement>> {
@@ -74,6 +107,12 @@ impl InlineElement {
 
 pub fn normalise_text_elements(slice: &mut Vec<InlineElement>) {
     let mut ix = 0;
+    for inl in slice.iter_mut() {
+        match inl {
+            | InlineElement::Micro(micros) => normalise_text_elements_micro(micros),
+            _ => {}
+        }
+    }
     while ix < slice.len().saturating_sub(1) {
         let mut pop_tail = false;
         if let Some(head) = slice.get_mut(ix) {
@@ -96,6 +135,22 @@ pub fn normalise_text_elements(slice: &mut Vec<InlineElement>) {
                     (InlineElement::Text(ref mut s), InlineElement::Text(s2)) => {
                         smash_string_push(s, &s2);
                         pop_tail = true;
+                    }
+                    (InlineElement::Formatted(children, _), InlineElement::Text(s2)) => {
+                        match children.last_mut().and_then(find_string_right_f) {
+                            Some(s1) => smash_just_punc(s1, s2),
+                            None => {}
+                        }
+                    }
+                    (InlineElement::Formatted(children, _), InlineElement::Micro(ms2)) => {
+                        info!("formatted, micro");
+                        match children.last_mut().and_then(find_string_right_f) {
+                            Some(s1) => match ms2.first_mut().and_then(find_string_left_micro) {
+                                Some(s2) => smash_just_punc(s1, s2),
+                                None => {}
+                            }
+                            None => {}
+                        }
                     }
                     (InlineElement::Micro(ref mut ms), InlineElement::Micro(ref mut ms2)) => {
                         // Only join if it doesn't end with a quoted
@@ -403,6 +458,27 @@ fn find_string_left(next: &mut InlineElement) -> Option<&mut String> {
         InlineElement::Text(ref mut string) => Some(string),
         InlineElement::Micro(ref mut micros) => micros.first_mut().and_then(find_string_left_micro),
         InlineElement::Quoted {..} => None,
+        _ => None,
+    }
+}
+
+/// Allows finding formatting?
+fn find_string_right_f(next: &mut InlineElement) -> Option<&mut String> {
+    match next {
+        InlineElement::Text(ref mut string) => Some(string),
+        InlineElement::Micro(ref mut micros) => micros.last_mut().and_then(find_string_right_f_micro),
+        InlineElement::Formatted(children, _) => children.last_mut().and_then(find_string_right_f),
+        InlineElement::Quoted {..} => None,
+        _ => None,
+    }
+}
+
+fn find_string_right_f_micro(m: &mut MicroNode) -> Option<&mut String> {
+    match m {
+        MicroNode::Text(string) => Some(string),
+        MicroNode::NoDecor(nodes) | MicroNode::NoCase(nodes) | MicroNode::Formatted(nodes, _) => {
+            nodes.last_mut().and_then(find_string_right_f_micro)
+        }
         _ => None,
     }
 }

--- a/crates/io/src/output/markup/move_punctuation.rs
+++ b/crates/io/src/output/markup/move_punctuation.rs
@@ -153,7 +153,7 @@ pub fn normalise_text_elements_micro(slice: &mut Vec<MicroNode>) {
     for inl in slice.iter_mut() {
         match inl {
             MicroNode::Quoted { children, .. }
-            | MicroNode::NoCase(children)
+            | MicroNode::NoDecor(children) | MicroNode::NoCase(children)
             | MicroNode::Formatted(children, _) => normalise_text_elements_micro(children),
             _ => {}
         }
@@ -391,7 +391,7 @@ fn is_punc_space(c: char) -> bool {
 fn find_string_left_micro(m: &mut MicroNode) -> Option<&mut String> {
     match m {
         MicroNode::Text(string) => Some(string),
-        MicroNode::NoCase(nodes) | MicroNode::Formatted(nodes, _) => {
+        MicroNode::NoDecor(nodes) | MicroNode::NoCase(nodes) | MicroNode::Formatted(nodes, _) => {
             nodes.first_mut().and_then(find_string_left_micro)
         }
         _ => None,
@@ -532,7 +532,7 @@ fn find_right_quote_inside_micro<'b>(micro: &'b mut MicroNode, next: &'b mut Str
             Some(RightQuoteInsertionPoint::InsideMicro(children, next))
         }
         // Dive into formatted bits
-        MicroNode::NoCase(nodes) | MicroNode::Formatted(nodes, _) => {
+        MicroNode::NoDecor(nodes) | MicroNode::NoCase(nodes) | MicroNode::Formatted(nodes, _) => {
             nodes.last_mut().and_then(move |x| find_right_quote_inside_micro(x, next))
         }
         _ => None,
@@ -627,7 +627,7 @@ fn last_string(is: &mut [InlineElement]) -> Option<&mut String> {
 fn last_string_micro(ms: &mut [MicroNode]) -> Option<&mut String> {
     ms.last_mut().and_then(|m| match m {
         MicroNode::Quoted { children, .. }
-        | MicroNode::NoCase(children)
+        | MicroNode::NoDecor(children) | MicroNode::NoCase(children)
         | MicroNode::Formatted(children, _) => {
             last_string_micro(children)
         }

--- a/crates/io/src/output/markup/parse_quotes.rs
+++ b/crates/io/src/output/markup/parse_quotes.rs
@@ -169,7 +169,7 @@ fn stamp<'a>(
             Intermediate::Index(ix) => {
                 let node = orig.get_mut(ix - drained).unwrap();
                 match node {
-                    MicroNode::Quoted { children, .. } | MicroNode::NoCase(children) | MicroNode::Formatted(children, _) => {
+                    MicroNode::Quoted { children, .. } | MicroNode::NoDecor(children)| MicroNode::NoCase(children) | MicroNode::Formatted(children, _) => {
                         let to_parse_owned = mem::replace(children, Vec::new());
                         let parsed = parse_quotes(to_parse_owned, options);
                         *children = parsed;
@@ -246,6 +246,7 @@ struct QuoteMatcher<'a> {
 fn leaning_text(node: &MicroNode, rightmost: bool) -> Option<&str> {
     match node {
         MicroNode::Quoted { ref children, .. }
+        | MicroNode::NoDecor(ref children)
         | MicroNode::NoCase(ref children)
         | MicroNode::Formatted(ref children, _) => if rightmost {
             children.last()
@@ -307,6 +308,7 @@ impl<'a> QuoteMatcher<'a> {
             .enumerate()
             .flat_map(move |(ix, node)| match node {
                 MicroNode::Quoted { .. }
+                | MicroNode::NoDecor(_)
                 | MicroNode::NoCase(_)
                 | MicroNode::Formatted(..) => EachSplitter::Index(Some(ix)),
                 MicroNode::Text(ref string) => {

--- a/crates/io/src/output/markup/plain.rs
+++ b/crates/io/src/output/markup/plain.rs
@@ -50,6 +50,9 @@ impl<'a> MarkupWriter for PlainWriter<'a> {
             NoCase(inners) => {
                 self.write_micros(inners);
             }
+            NoDecor(inners) => {
+                self.write_micros(inners);
+            }
         }
     }
 

--- a/crates/io/src/output/markup/rtf.rs
+++ b/crates/io/src/output/markup/rtf.rs
@@ -64,6 +64,9 @@ impl<'a> MarkupWriter for RtfWriter<'a> {
             NoCase(inners) => {
                 self.write_micros(inners);
             }
+            NoDecor(inners) => {
+                self.write_micros(inners);
+            }
         }
     }
 

--- a/crates/io/src/output/micro_html.rs
+++ b/crates/io/src/output/micro_html.rs
@@ -18,8 +18,9 @@ pub enum MicroNode {
         children: Vec<MicroNode>,
     },
 
-    /// TODO: text-casing during ingestion
     NoCase(Vec<MicroNode>),
+
+    NoDecor(Vec<MicroNode>),
 }
 
 impl MicroNode {
@@ -95,6 +96,7 @@ impl HtmlReader<String> for PlainHtmlReader {
                 [("style", "font-variant:small-caps;")]
                 | [("style", "font-variant: small-caps;")] => children,
                 [("class", "nocase")] => children,
+                [("class", "nodecor")] => children,
                 _ => return vec![],
             },
             _ => return vec![],
@@ -125,6 +127,7 @@ impl HtmlReader<MicroNode> for MicroHtmlReader<'_> {
                     MicroNode::Formatted(children, FormatCmd::FontVariantSmallCaps)
                 }
                 [("class", "nocase")] => MicroNode::NoCase(children),
+                [("class", "nodecor")] => MicroNode::NoDecor(children),
                 _ => return vec![],
             },
             _ => return vec![],

--- a/crates/proc/src/db.rs
+++ b/crates/proc/src/db.rs
@@ -937,9 +937,14 @@ pub fn built_cluster_before_output(
         let flattened = ir.flatten(&fmt)?;
         let mut pre = Cow::from(cite.prefix.as_ref().map(AsRef::as_ref).unwrap_or(""));
         let mut suf = Cow::from(cite.suffix.as_ref().map(AsRef::as_ref).unwrap_or(""));
-        if pre.ends_with(".") {
+        if !pre.is_empty() && !pre.ends_with(' ') {
             let pre_mut = pre.to_mut();
             pre_mut.push(' ');
+        }
+        let suf_first = suf.chars().nth(0);
+        if suf_first.map_or(false, |x| x != ' ' && !citeproc_io::output::markup::is_punc(x)) {
+            let suf_mut = suf.to_mut();
+            suf_mut.insert_str(0, " ");
         }
         // TODO: custom procedure for joining user-supplied cite affixes, which should interact
         // with terminal punctuation by overriding rather than joining in the usual way.


### PR DESCRIPTION
- Insert spaces into cite suffixes when they aren't terminated by punctuation
- Smash together more punctuation, more often
- Support `<span class="nodecor">` by removing all formatting for that span

Includes iso language suffixes, VariousinValidDates.