### PR TITLE
Configure wasm-opt to avoid 'exported global cannot be mutable'

### DIFF
--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -66,3 +66,8 @@ wasm-bindgen-test = "0.3.17"
 # # Tell `rustc` to optimize for small code size.
 # opt-level = "s"
 # lto = true
+
+# https://github.com/rustwasm/wasm-pack/issues/886#issuecomment-667669802
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ["-O3", "--enable-mutable-globals"]
+


### PR DESCRIPTION
This is because --features console triggered it.
