### PR TITLE
Uncited Items API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,9 +61,9 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-test-suite-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-
+            ${{ runner.os }}-cargo-test-suite-
       - name: "Build tools package"
         run: cargo build --package tools
       - name: "Pull locales"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
 
 [[package]]
+name = "autocfg"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
+
+[[package]]
 name = "backtrace"
 version = "0.3.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -286,7 +292,7 @@ dependencies = [
  "lazy_static",
  "log",
  "nom 5.0.1",
- "parking_lot",
+ "parking_lot 0.9.0",
  "petgraph",
  "pretty_assertions",
  "salsa",
@@ -331,6 +337,15 @@ name = "cloudabi"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "cloudabi"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4344512281c643ae7638bbabc3af17a11307803ec8f0fcad9fae512a8bf36467"
 dependencies = [
  "bitflags",
 ]
@@ -423,36 +438,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69323bff1fb41c635347b8ead484a5ca6c3f11914d784170b158d8449ab07f8e"
-dependencies = [
- "cfg-if",
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils 0.7.0",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acec9a3b0b3559f15aee4f90746c4e5e293b701c0f7d3925d24e01645267b68c"
-dependencies = [
- "crossbeam-utils 0.7.0",
-]
-
-[[package]]
 name = "crossbeam-deque"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3aa945d63861bfe624b55d153a39684da1e8c0bc8fba932f7ee3a3c16cea3ca"
 dependencies = [
  "crossbeam-epoch",
- "crossbeam-utils 0.7.0",
+ "crossbeam-utils 0.7.2",
 ]
 
 [[package]]
@@ -461,9 +453,9 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5064ebdbf05ce3cb95e45c8b086f72263f4166b29b97f6baff7ef7fe047b55ac"
 dependencies = [
- "autocfg",
+ "autocfg 0.1.7",
  "cfg-if",
- "crossbeam-utils 0.7.0",
+ "crossbeam-utils 0.7.2",
  "lazy_static",
  "memoffset",
  "scopeguard",
@@ -475,7 +467,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfd6515864a82d2f877b42813d4553292c6659498c9a2aa31bab5a15243c2700"
 dependencies = [
- "crossbeam-utils 0.7.0",
+ "crossbeam-utils 0.7.2",
 ]
 
 [[package]]
@@ -490,11 +482,11 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce446db02cdc3165b94ae73111e570793400d0794e46125cc4056c81cbb039f4"
+checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.0",
  "cfg-if",
  "lazy_static",
 ]
@@ -566,17 +558,6 @@ dependencies = [
 name = "datatest-derive"
 version = "0.5.3-alpha.0"
 source = "git+https://github.com/cormacrelf/datatest?branch=test_type#e267a78dac1e863d5f539e7074fef81827727f74"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "derive-new"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71f31892cd5c62e414316f2963c5689242c43d8e7bbcaaeca97e5e28c95d91d9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -814,7 +795,7 @@ version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712d7b3ea5827fcb9d4fda14bf4da5f136f0db2ae9c8f4bd4e2d1c6fde4e6db2"
 dependencies = [
- "autocfg",
+ "autocfg 0.1.7",
 ]
 
 [[package]]
@@ -831,6 +812,12 @@ dependencies = [
  "serde_yaml",
  "uuid",
 ]
+
+[[package]]
+name = "instant"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b141fdc7836c525d4d594027d318c84161ca17aaf8113ab1f81ab93ae897485"
 
 [[package]]
 name = "is_executable"
@@ -905,9 +892,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.66"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
+checksum = "a2f02823cf78b754822df5f7f268fb59822e7296276d3e069d8e8cb26a14bd10"
 
 [[package]]
 name = "libgit2-sys"
@@ -959,6 +946,15 @@ checksum = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
 name = "lock_api"
 version = "0.3.1"
 source = "git+https://github.com/cormacrelf/parking_lot.git?branch=wasm32#8fa2fd35fd8c74c7e959744b1ac47987cdd47f53"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
+name = "lock_api"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28247cc5a5be2f05fbcd76dd0cf2c7d3b5400cb978a28042abcd4fa0b3f8261c"
 dependencies = [
  "scopeguard",
 ]
@@ -1057,7 +1053,7 @@ version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
 dependencies = [
- "autocfg",
+ "autocfg 0.1.7",
  "num-traits",
 ]
 
@@ -1067,7 +1063,7 @@ version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4c81ffc11c212fa327657cb19dd85eb7419e163b5b076bede2bdb5c974c07e4"
 dependencies = [
- "autocfg",
+ "autocfg 0.1.7",
 ]
 
 [[package]]
@@ -1104,7 +1100,7 @@ version = "0.9.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "465d16ae7fc0e313318f7de5cecf57b2fbe7511fd213978b457e1c96ff46736f"
 dependencies = [
- "autocfg",
+ "autocfg 0.1.7",
  "cc",
  "libc",
  "pkg-config",
@@ -1150,10 +1146,21 @@ name = "parking_lot"
 version = "0.9.0"
 source = "git+https://github.com/cormacrelf/parking_lot.git?branch=wasm32#8fa2fd35fd8c74c7e959744b1ac47987cdd47f53"
 dependencies = [
- "autocfg",
+ "autocfg 0.1.7",
  "cfg-if",
- "lock_api",
- "parking_lot_core",
+ "lock_api 0.3.1",
+ "parking_lot_core 0.6.2",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4893845fa2ca272e647da5d0e46660a314ead9c2fdd9a883aabc32e481a8733"
+dependencies = [
+ "instant",
+ "lock_api 0.4.1",
+ "parking_lot_core 0.8.0",
 ]
 
 [[package]]
@@ -1161,12 +1168,27 @@ name = "parking_lot_core"
 version = "0.6.2"
 source = "git+https://github.com/cormacrelf/parking_lot.git?branch=wasm32#8fa2fd35fd8c74c7e959744b1ac47987cdd47f53"
 dependencies = [
- "autocfg",
+ "autocfg 0.1.7",
  "cfg-if",
- "cloudabi",
+ "cloudabi 0.0.3",
  "libc",
  "redox_syscall",
  "smallvec 0.6.13",
+ "winapi",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c361aa727dd08437f2f1447be8b59a33b0edd15e0fcee698f935613d9efbca9b"
+dependencies = [
+ "cfg-if",
+ "cloudabi 0.1.0",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec 1.4.1",
  "winapi",
 ]
 
@@ -1362,7 +1384,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
 dependencies = [
- "autocfg",
+ "autocfg 0.1.7",
  "libc",
  "rand_chacha 0.1.1",
  "rand_core 0.4.2",
@@ -1395,7 +1417,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
 dependencies = [
- "autocfg",
+ "autocfg 0.1.7",
  "rand_core 0.3.1",
 ]
 
@@ -1477,7 +1499,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
 dependencies = [
- "cloudabi",
+ "cloudabi 0.0.3",
  "fuchsia-cprng",
  "libc",
  "rand_core 0.4.2",
@@ -1491,7 +1513,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
 dependencies = [
- "autocfg",
+ "autocfg 0.1.7",
  "rand_core 0.4.2",
 ]
 
@@ -1532,7 +1554,7 @@ checksum = "08a89b46efaf957e52b18062fb2f4660f8b8a4dde1807ca002690868ef2c85a9"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-queue",
- "crossbeam-utils 0.7.0",
+ "crossbeam-utils 0.7.2",
  "lazy_static",
  "num_cpus",
 ]
@@ -1643,26 +1665,26 @@ checksum = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
 
 [[package]]
 name = "salsa"
-version = "0.13.2"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0865bdd9d8e614686a0cbb76979c735810131d287eb1683e91e4e64a58c387"
+checksum = "9ab29056d4fb4048a5f0d169c9b6e5526160c9ec37aded5a6879c2c9c445a8e4"
 dependencies = [
- "crossbeam",
- "derive-new",
+ "crossbeam-utils 0.7.2",
  "indexmap",
+ "lock_api 0.4.1",
  "log",
- "parking_lot",
- "rand 0.7.2",
+ "oorandom",
+ "parking_lot 0.11.0",
  "rustc-hash",
  "salsa-macros",
- "smallvec 0.6.13",
+ "smallvec 1.4.1",
 ]
 
 [[package]]
 name = "salsa-macros"
-version = "0.13.2"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cac182212d3a1db75ddc42399ff1461b258a694b8318ee7e0baf6c976e39efee"
+checksum = "a1c3aec007c63c4ed4cd7a018529fb0b5575c4562575fc6a40d6cd2ae0b792ef"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1687,9 +1709,9 @@ checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
 
 [[package]]
 name = "scopeguard"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "semver"
@@ -1783,9 +1805,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.0.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ecf3b85f68e8abaa7555aa5abdb1153079387e60b718283d732f03897fcfc86"
+checksum = "3757cb9d89161a2f24e1cf78efa0c1fcff485d18e3f55e0aa3480824ddaa0f3f"
 
 [[package]]
 name = "string_cache"
@@ -1864,9 +1886,9 @@ checksum = "e5d1c33039533f051704951680f1adfd468fd37ac46816ded0d9ee068e60f05f"
 
 [[package]]
 name = "strum_macros"
-version = "0.19.2"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2ab682ecdcae7f5f45ae85cd7c1e6c8e68ea42c8a612d47fedf831c037146a"
+checksum = "875812c05b8135f41dc640a3e268bdebbd832576a05cf56471fc1eb70c602eb6"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2137,7 +2159,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b561e267b2326bb4cebfc0ef9e68355c7abe6c6f522aeac2f5bf95d56c59bdcf"
 dependencies = [
- "smallvec 1.0.0",
+ "smallvec 1.4.1",
 ]
 
 [[package]]

--- a/crates/citeproc/Cargo.toml
+++ b/crates/citeproc/Cargo.toml
@@ -31,7 +31,7 @@ jemalloc = ["jemallocator"]
 rayon = { version = "1.2.0", optional = true }
 cfg-if = "0.1.10"
 fnv = "1.0.6"
-salsa = "0.13.0"
+salsa = "0.15.2"
 log = "0.4.8"
 serde = { version = "1.0.100", features = ["rc"] }
 serde_derive = "1.0.100"

--- a/crates/citeproc/src/db/update.rs
+++ b/crates/citeproc/src/db/update.rs
@@ -75,7 +75,7 @@ pub struct UpdateSummary<O: OutputFormat = Markup> {
 }
 
 impl UpdateSummary {
-    pub fn summarize(db: &impl IrDatabase, updates: &[DocUpdate]) -> Self {
+    pub fn summarize(db: &dyn IrDatabase, updates: &[DocUpdate]) -> Self {
         let ids = updates.iter().map(|&u| match u {
             DocUpdate::Cluster(x) => x,
         });

--- a/crates/citeproc/src/lib.rs
+++ b/crates/citeproc/src/lib.rs
@@ -9,13 +9,18 @@ extern crate serde_derive;
 // #[macro_use]
 // extern crate log;
 
-pub(crate) mod db;
-pub use self::db::update::{DocUpdate, UpdateSummary};
-pub use self::db::{ErrorKind, Processor};
+pub(crate) mod processor;
+pub(crate) mod api;
+
+#[cfg(test)]
+mod test;
+
+pub use self::api::{DocUpdate, UpdateSummary, IncludeUncited, SupportedFormat};
+pub use self::processor::{ErrorKind, Processor};
 
 pub mod prelude {
-    pub use crate::db::update::{DocUpdate, UpdateSummary};
-    pub use crate::db::{Processor, SupportedFormat};
+    pub use crate::api::{DocUpdate, UpdateSummary, IncludeUncited, SupportedFormat};
+    pub use crate::processor::Processor;
     pub use citeproc_db::{
         CiteDatabase, CiteId, LocaleDatabase, LocaleFetchError, LocaleFetcher, StyleDatabase,
     };

--- a/crates/citeproc/src/processor.rs
+++ b/crates/citeproc/src/processor.rs
@@ -16,6 +16,7 @@ use crate::api::{
 };
 use citeproc_db::{
     CiteDatabaseStorage, HasFetcher, LocaleDatabaseStorage, StyleDatabaseStorage, Uncited,
+    CiteData,
 };
 use citeproc_proc::db::IrDatabaseStorage;
 
@@ -311,7 +312,11 @@ impl Processor {
             } = cluster;
             let mut ids = Vec::new();
             for (index, cite) in cites.into_iter().enumerate() {
-                let cite_id = self.cite(cluster_id, index as u32, Arc::new(cite));
+                let cite_id = self.cite(CiteData::RealCite {
+                    cluster: cluster_id,
+                    index: index as u32,
+                    cite: Arc::new(cite),
+                });
                 ids.push(cite_id);
             }
             self.set_cluster_cites(cluster_id, Arc::new(ids));
@@ -350,7 +355,11 @@ impl Processor {
 
         let mut ids = Vec::new();
         for (index, cite) in cites.iter().enumerate() {
-            let cite_id = self.cite(cluster_id, index as u32, Arc::new(cite.clone()));
+            let cite_id = self.cite(CiteData::RealCite {
+                cluster: cluster_id,
+                index: index as u32,
+                cite: Arc::new(cite.clone()),
+            });
             ids.push(cite_id);
         }
         self.set_cluster_cites(cluster_id, Arc::new(ids));

--- a/crates/citeproc/src/test.rs
+++ b/crates/citeproc/src/test.rs
@@ -8,8 +8,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use csl::*;
-
-use super::Processor;
+use crate::prelude::*;
 
 mod position {
     use super::*;

--- a/crates/citeproc/tests/suite.rs
+++ b/crates/citeproc/tests/suite.rs
@@ -100,7 +100,6 @@ fn csl_test_suite(path: &Path) {
     let mut test_case = parse_human_test(&input);
     if let Some(res) = test_case.execute() {
         let pass = res == test_case.result;
-        let fname = path.file_name().unwrap().to_string_lossy();
         if !pass && is_snapshot(path) {
             insta::assert_snapshot!(res);
         } else {

--- a/crates/csl/src/style/mod.rs
+++ b/crates/csl/src/style/mod.rs
@@ -950,7 +950,7 @@ impl Citation {
         let col = self.collapse;
         match self.cite_group_delimiter.as_ref() {
             Some(cgd) => Some((cgd.as_ref(), col)),
-            None => col.map(|c| (", ", col)),
+            None => col.map(|c| (", ", Some(c))),
         }
     }
 }

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 parallel = []
 
 [dependencies]
-salsa = "0.13.0"
+salsa = "0.15.2"
 fnv = "1.0.6"
 csl = { path = "../csl" }
 citeproc-io = { path = "../io" }

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -13,6 +13,6 @@ pub fn safe_default(db: &mut (impl cite::CiteDatabase + xml::LocaleDatabase + xm
     db.set_style(Default::default());
     db.set_all_keys(Default::default());
     db.set_all_uncited(Default::default());
-    db.set_cluster_ids(Arc::new(vec![]));
+    db.set_cluster_ids(Arc::new(Default::default()));
     db.set_locale_input_langs(Default::default());
 }

--- a/crates/proc/Cargo.toml
+++ b/crates/proc/Cargo.toml
@@ -15,7 +15,7 @@ ucd-trie = "0.1.2"
 petgraph = "0.4.13"
 generational-arena = "0.2.2"
 cfg-if = "0.1.9"
-salsa = "0.13.0"
+salsa = "0.15.2"
 citeproc-db = { path = "../db" }
 strum = "0.15.0"
 log = "0.4.8"

--- a/crates/proc/src/choose.rs
+++ b/crates/proc/src/choose.rs
@@ -22,7 +22,7 @@ where
 {
     fn intermediate(
         &self,
-        db: &impl IrDatabase,
+        db: &dyn IrDatabase,
         state: &mut IrState,
         ctx: &CiteContext<'c, O, I>,
     ) -> IrSum<O> {
@@ -85,7 +85,7 @@ where
 impl Disambiguation<Markup> for Choose {
     fn ref_ir(
         &self,
-        db: &impl IrDatabase,
+        db: &dyn IrDatabase,
         ctx: &RefContext<Markup>,
         state: &mut IrState,
         stack: Formatting,
@@ -110,7 +110,7 @@ struct BranchEval<O: OutputFormat> {
 }
 
 fn eval_ifthen<'c, O, I>(
-    db: &impl IrDatabase,
+    db: &dyn IrDatabase,
     branch: &'c IfThen,
     state: &mut IrState,
     ctx: &CiteContext<'c, O, I>,

--- a/crates/proc/src/date.rs
+++ b/crates/proc/src/date.rs
@@ -85,7 +85,7 @@ fn to_ref_ir(
 impl Either<Markup> {
     fn into_ref_ir(
         self,
-        db: &impl IrDatabase,
+        db: &dyn IrDatabase,
         ctx: &RefContext<Markup>,
         stack: Formatting,
     ) -> (RefIR, GroupVars) {
@@ -121,7 +121,7 @@ where
 {
     fn intermediate(
         &self,
-        _db: &impl IrDatabase,
+        _db: &dyn IrDatabase,
         _state: &mut IrState,
         ctx: &CiteContext<'c, O, I>,
     ) -> IrSum<O> {
@@ -144,7 +144,7 @@ where
 impl Disambiguation<Markup> for BodyDate {
     fn ref_ir(
         &self,
-        db: &impl IrDatabase,
+        db: &dyn IrDatabase,
         ctx: &RefContext<Markup>,
         _state: &mut IrState,
         stack: Formatting,

--- a/crates/proc/src/db.rs
+++ b/crates/proc/src/db.rs
@@ -1164,7 +1164,7 @@ pub fn with_cite_context<T>(
         disamb_pass: None,
         style: &style,
         locale: &locale,
-        bib_number: db.bib_number(id),
+        bib_number,
         in_bibliography: false,
         names_delimiter,
         name_citation: name_el,

--- a/crates/proc/src/db.rs
+++ b/crates/proc/src/db.rs
@@ -94,6 +94,7 @@ pub trait IrDatabase: CiteDatabase + LocaleDatabase + StyleDatabase + HasFormatt
 
     #[salsa::invoke(crate::sort::sorted_refs)]
     fn sorted_refs(&self) -> Arc<(Vec<Atom>, FnvHashMap<Atom, u32>)>;
+
     #[salsa::invoke(crate::sort::sort_string_citation)]
     fn sort_string_citation(
         &self,
@@ -112,7 +113,7 @@ pub trait IrDatabase: CiteDatabase + LocaleDatabase + StyleDatabase + HasFormatt
     fn bib_number(&self, id: CiteId) -> Option<u32>;
 }
 
-fn all_person_names(db: &impl IrDatabase) -> Arc<Vec<DisambName>> {
+fn all_person_names(db: &dyn IrDatabase) -> Arc<Vec<DisambName>> {
     let _style = db.style();
     let name_configurations = db.name_configurations();
     let refs = db.disamb_participants();
@@ -147,20 +148,20 @@ fn all_person_names(db: &impl IrDatabase) -> Arc<Vec<DisambName>> {
 
 use crate::disamb::create_dfa;
 
-fn ref_dfa<DB: IrDatabase>(db: &DB, key: Atom) -> Option<Arc<Dfa>> {
+fn ref_dfa(db: &dyn IrDatabase, key: Atom) -> Option<Arc<Dfa>> {
     if let Some(refr) = db.reference(key) {
-        Some(Arc::new(create_dfa::<Markup, DB>(db, &refr)))
+        Some(Arc::new(create_dfa::<Markup>(db, &refr)))
     } else {
         None
     }
 }
 
-fn branch_runs(db: &impl IrDatabase) -> Arc<FreeCondSets> {
+fn branch_runs(db: &dyn IrDatabase) -> Arc<FreeCondSets> {
     use crate::disamb::get_free_conds;
     Arc::new(get_free_conds(db))
 }
 
-fn year_suffix_for(db: &impl IrDatabase, ref_id: Atom) -> Option<u32> {
+fn year_suffix_for(db: &dyn IrDatabase, ref_id: Atom) -> Option<u32> {
     let ys = db.year_suffixes();
     ys.get(&ref_id).cloned()
 }
@@ -180,7 +181,7 @@ fn year_suffix_for(db: &impl IrDatabase, ref_id: Atom) -> Option<u32> {
 ///    a. Groups = {}
 ///    b. For each cite A with more than its own, find, if any, a Group whose total refs intersects A.refs
 ///    c. If found G, add A to that group, and G.total_refs = G.total_refs UNION A.refs
-fn year_suffixes(db: &impl IrDatabase) -> Arc<FnvHashMap<Atom, u32>> {
+fn year_suffixes(db: &dyn IrDatabase) -> Arc<FnvHashMap<Atom, u32>> {
     use fnv::FnvHashSet;
     let style = db.style();
     if !style.citation.disambiguate_add_year_suffix {
@@ -271,7 +272,7 @@ fn year_suffixes(db: &impl IrDatabase) -> Arc<FnvHashMap<Atom, u32>> {
 }
 
 // Not cached
-fn ref_bib_number(db: &impl IrDatabase, ref_id: &Atom) -> u32 {
+fn ref_bib_number(db: &dyn IrDatabase, ref_id: &Atom) -> u32 {
     let srs = db.sorted_refs();
     let (_, ref lookup_ref_ids) = &*srs;
     let ret = lookup_ref_ids.get(ref_id).cloned();
@@ -321,7 +322,7 @@ impl PartialEq<IrGen> for IrGen {
     }
 }
 
-fn ref_not_found(db: &impl IrDatabase, ref_id: &Atom, log: bool) -> Arc<IrGen> {
+fn ref_not_found(db: &dyn IrDatabase, ref_id: &Atom, log: bool) -> Arc<IrGen> {
     if log {
         eprintln!("citeproc-rs: reference {} not found", ref_id);
     }
@@ -363,7 +364,7 @@ macro_rules! preamble {
 }
 
 fn is_unambiguous(
-    db: &impl IrDatabase,
+    db: &dyn IrDatabase,
     _pass: Option<DisambPass>,
     ir: &IR<Markup>,
     _cite_id: Option<CiteId>,
@@ -386,7 +387,7 @@ fn is_unambiguous(
 
 /// Returns the set of Reference IDs that could have produced a cite's IR
 fn refs_accepting_cite<O: OutputFormat>(
-    db: &impl IrDatabase,
+    db: &dyn IrDatabase,
     ir: &IR<Markup>,
     ctx: &CiteContext<'_, O>,
 ) -> Vec<Atom> {
@@ -434,8 +435,8 @@ fn refs_accepting_cite<O: OutputFormat>(
 /// 3. We can then use this narrowed-down matcher to test, locally, whether name expansions are narrowing
 ///    down the cite's ambiguity, without having to zip in and out or use a mutex.
 
-fn make_identical_name_formatter<'a, DB: IrDatabase>(
-    db: &DB,
+fn make_identical_name_formatter<'a>(
+    db: &dyn IrDatabase,
     ref_id: Atom,
     cite_ctx: &'a CiteContext<'a, Markup>,
     index: u32,
@@ -443,7 +444,7 @@ fn make_identical_name_formatter<'a, DB: IrDatabase>(
     use crate::disamb::create_single_ref_ir;
     let refr = db.reference(ref_id)?;
     let ref_ctx = RefContext::from_cite_context(&refr, cite_ctx);
-    let ref_ir = create_single_ref_ir::<Markup, DB>(db, &ref_ctx);
+    let ref_ir = create_single_ref_ir::<Markup>(db, &ref_ctx);
     fn find_name_block<'a>(ref_ir: &'a RefIR, nth: &mut u32) -> Option<&'a RefNameIR> {
         match ref_ir {
             RefIR::Edge(_) => None,
@@ -522,7 +523,7 @@ fn list_all_cond_disambs(ir: &IR<Markup>) -> Vec<CondDisambRef> {
 use crate::disamb::names::{DisambNameRatchet, NameIR, NameVariantMatcher, RefNameIR};
 
 fn disambiguate_add_names(
-    db: &impl IrDatabase,
+    db: &dyn IrDatabase,
     ir: &mut IR<Markup>,
     ctx: &CiteContext<'_, Markup>,
     also_expand: bool,
@@ -596,7 +597,7 @@ fn disambiguate_add_names(
 }
 
 fn expand_one_name_ir(
-    db: &impl IrDatabase,
+    db: &dyn IrDatabase,
     _ir: &IR<Markup>,
     ctx: &CiteContext<'_, Markup>,
     refs_accepting: &[Atom],
@@ -669,7 +670,7 @@ fn expand_one_name_ir(
 }
 
 fn disambiguate_add_givennames(
-    db: &impl IrDatabase,
+    db: &dyn IrDatabase,
     ir: &mut IR<Markup>,
     ctx: &CiteContext<'_, Markup>,
     also_add: bool,
@@ -689,7 +690,7 @@ fn disambiguate_add_givennames(
 }
 
 fn disambiguate_add_year_suffix(
-    db: &impl IrDatabase,
+    db: &dyn IrDatabase,
     ir: &mut IR<Markup>,
     state: &mut IrState,
     ctx: &CiteContext<'_, Markup>,
@@ -730,7 +731,7 @@ fn disambiguate_add_year_suffix(
 }
 
 fn disambiguate_true(
-    db: &impl IrDatabase,
+    db: &dyn IrDatabase,
     ir: &mut IR<Markup>,
     state: &mut IrState,
     ctx: &CiteContext<'_, Markup>,
@@ -760,7 +761,7 @@ fn disambiguate_true(
     }
 }
 
-fn ir_gen0(db: &impl IrDatabase, id: CiteId) -> Arc<IrGen> {
+fn ir_gen0(db: &dyn IrDatabase, id: CiteId) -> Arc<IrGen> {
     let style;
     let locale;
     let cite;
@@ -774,7 +775,7 @@ fn ir_gen0(db: &impl IrDatabase, id: CiteId) -> Arc<IrGen> {
     Arc::new(IrGen::new(ir, matching, state))
 }
 
-fn ir_gen1_add_names(db: &impl IrDatabase, id: CiteId) -> Arc<IrGen> {
+fn ir_gen1_add_names(db: &dyn IrDatabase, id: CiteId) -> Arc<IrGen> {
     let style;
     let locale;
     let cite;
@@ -795,7 +796,7 @@ fn ir_gen1_add_names(db: &impl IrDatabase, id: CiteId) -> Arc<IrGen> {
     Arc::new(IrGen::new(ir, matching, state))
 }
 
-fn ir_gen2_add_given_name(db: &impl IrDatabase, id: CiteId) -> Arc<IrGen> {
+fn ir_gen2_add_given_name(db: &dyn IrDatabase, id: CiteId) -> Arc<IrGen> {
     let style;
     let locale;
     let cite;
@@ -817,7 +818,7 @@ fn ir_gen2_add_given_name(db: &impl IrDatabase, id: CiteId) -> Arc<IrGen> {
     Arc::new(IrGen::new(ir, matching, state))
 }
 
-fn ir_gen3_add_year_suffix(db: &impl IrDatabase, id: CiteId) -> Arc<IrGen> {
+fn ir_gen3_add_year_suffix(db: &dyn IrDatabase, id: CiteId) -> Arc<IrGen> {
     let style;
     let locale;
     let cite;
@@ -841,7 +842,7 @@ fn ir_gen3_add_year_suffix(db: &impl IrDatabase, id: CiteId) -> Arc<IrGen> {
     Arc::new(IrGen::new(ir, matching, state))
 }
 
-fn ir_gen4_conditionals(db: &impl IrDatabase, id: CiteId) -> Arc<IrGen> {
+fn ir_gen4_conditionals(db: &dyn IrDatabase, id: CiteId) -> Arc<IrGen> {
     let style;
     let locale;
     let cite;
@@ -862,7 +863,7 @@ fn ir_gen4_conditionals(db: &impl IrDatabase, id: CiteId) -> Arc<IrGen> {
     Arc::new(IrGen::new(ir, matching, state))
 }
 
-fn get_piq(db: &impl IrDatabase) -> bool {
+fn get_piq(db: &dyn IrDatabase) -> bool {
     // We pant PIQ to be global in a document, not change within a cluster because one cite
     // decided to use a different language. Use the default locale to get it.
     let default_locale = db.default_locale();
@@ -870,7 +871,7 @@ fn get_piq(db: &impl IrDatabase) -> bool {
 }
 
 fn built_cluster(
-    db: &impl IrDatabase,
+    db: &dyn IrDatabase,
     cluster_id: ClusterId,
 ) -> Arc<<Markup as OutputFormat>::Output> {
     let fmt = db.get_formatter();
@@ -880,7 +881,7 @@ fn built_cluster(
 }
 
 pub fn built_cluster_before_output(
-    db: &impl IrDatabase,
+    db: &dyn IrDatabase,
     cluster_id: ClusterId,
 ) -> <Markup as OutputFormat>::Build {
     let fmt = db.get_formatter();
@@ -1136,7 +1137,7 @@ pub fn built_cluster_before_output(
 
 /// None if the reference being cited does not exist
 pub fn with_cite_context<T>(
-    db: &impl IrDatabase,
+    db: &dyn IrDatabase,
     id: CiteId,
     bib_number: Option<u32>,
     sort_key: Option<SortKey>,
@@ -1177,7 +1178,7 @@ pub fn with_cite_context<T>(
 // mutate.
 
 pub fn with_bib_context<T>(
-    db: &impl IrDatabase,
+    db: &dyn IrDatabase,
     ref_id: Atom,
     bib_number: Option<u32>,
     sort_key: Option<SortKey>,
@@ -1210,7 +1211,7 @@ pub fn with_bib_context<T>(
     Some(f(bib, ctx))
 }
 
-fn bib_item_gen0(db: &impl IrDatabase, ref_id: Atom) -> Option<Arc<IrGen>> {
+fn bib_item_gen0(db: &dyn IrDatabase, ref_id: Atom) -> Option<Arc<IrGen>> {
     let sorted_refs_arc = db.sorted_refs();
     let (_keys, citation_numbers_by_id) = &*sorted_refs_arc;
     let bib_number = *citation_numbers_by_id
@@ -1250,7 +1251,7 @@ fn bib_item_gen0(db: &impl IrDatabase, ref_id: Atom) -> Option<Arc<IrGen>> {
     )
 }
 
-fn bib_item(db: &impl IrDatabase, ref_id: Atom) -> Arc<MarkupOutput> {
+fn bib_item(db: &dyn IrDatabase, ref_id: Atom) -> Arc<MarkupOutput> {
     let fmt = db.get_formatter();
     let style = db.style();
     if let Some(gen0) = db.bib_item_gen0(ref_id) {
@@ -1266,7 +1267,7 @@ fn bib_item(db: &impl IrDatabase, ref_id: Atom) -> Arc<MarkupOutput> {
     }
 }
 
-fn get_bibliography_map(db: &impl IrDatabase) -> Arc<FnvHashMap<Atom, Arc<MarkupOutput>>> {
+fn get_bibliography_map(db: &dyn IrDatabase) -> Arc<FnvHashMap<Atom, Arc<MarkupOutput>>> {
     let fmt = db.get_formatter();
     let style = db.style();
     let sorted_refs = db.sorted_refs();
@@ -1307,7 +1308,7 @@ fn get_bibliography_map(db: &impl IrDatabase) -> Arc<FnvHashMap<Atom, Arc<Markup
 }
 
 // See https://github.com/jgm/pandoc-citeproc/blob/e36c73ac45c54dec381920e92b199787601713d1/src/Text/CSL/Reference.hs#L910
-fn cite_positions(db: &impl IrDatabase) -> Arc<FnvHashMap<CiteId, (Position, Option<u32>)>> {
+fn cite_positions(db: &dyn IrDatabase) -> Arc<FnvHashMap<CiteId, (Position, Option<u32>)>> {
     let clusters = db.clusters_cites_sorted();
 
     let mut map = FnvHashMap::default();
@@ -1527,7 +1528,7 @@ fn cite_positions(db: &impl IrDatabase) -> Arc<FnvHashMap<CiteId, (Position, Opt
     Arc::new(map)
 }
 
-fn cite_position(db: &impl IrDatabase, key: CiteId) -> (Position, Option<u32>) {
+fn cite_position(db: &dyn IrDatabase, key: CiteId) -> (Position, Option<u32>) {
     if let Some(x) = db.cite_positions().get(&key) {
         *x
     } else {

--- a/crates/proc/src/db.rs
+++ b/crates/proc/src/db.rs
@@ -283,7 +283,7 @@ fn ref_bib_number(db: &dyn IrDatabase, ref_id: &Atom) -> u32 {
             "called ref_bib_number on a ref_id {} that is unknown/not in the bibliography",
             ref_id
         );
-        // For uncited reference ids, we assign them year-suffixes after the rest.
+        // Let's not fail, just give it one after the rest.
         std::u32::MAX
     }
 }

--- a/crates/proc/src/disamb/finite_automata.rs
+++ b/crates/proc/src/disamb/finite_automata.rs
@@ -65,7 +65,7 @@ impl Hash for EdgeData {
 impl Edge {
     // Adding this method is often convenient, since you can then
     // write `path.lookup(db)` to access the data, which reads a bit better.
-    pub fn lookup(self, db: &impl IrDatabase) -> EdgeData {
+    pub fn lookup(self, db: &dyn IrDatabase) -> EdgeData {
         IrDatabase::lookup_edge(db, self)
     }
 }
@@ -159,7 +159,7 @@ enum DebugNode {
 }
 
 impl Dfa {
-    pub fn debug_graph(&self, db: &impl IrDatabase) -> String {
+    pub fn debug_graph(&self, db: &dyn IrDatabase) -> String {
         let g = self.graph.map(
             |node, _| {
                 let cont = self.accepting.contains(&node);
@@ -316,7 +316,7 @@ pub fn to_dfa(nfa: &Nfa) -> Dfa {
 }
 
 impl Dfa {
-    pub fn accepts_data(&self, db: &impl IrDatabase, data: &[EdgeData]) -> bool {
+    pub fn accepts_data(&self, db: &dyn IrDatabase, data: &[EdgeData]) -> bool {
         let mut cursors = Vec::new();
         cursors.push((self.start, None, data));
         while !cursors.is_empty() {

--- a/crates/proc/src/disamb/implementation.rs
+++ b/crates/proc/src/disamb/implementation.rs
@@ -13,7 +13,7 @@ use csl::*;
 impl Disambiguation<Markup> for Style {
     fn ref_ir(
         &self,
-        db: &impl IrDatabase,
+        db: &dyn IrDatabase,
         ctx: &RefContext<Markup>,
         state: &mut IrState,
         stack: Formatting,
@@ -37,7 +37,7 @@ impl Disambiguation<Markup> for Style {
 impl Disambiguation<Markup> for Group {
     fn ref_ir(
         &self,
-        db: &impl IrDatabase,
+        db: &dyn IrDatabase,
         ctx: &RefContext<Markup>,
         state: &mut IrState,
         stack: Formatting,
@@ -64,7 +64,7 @@ impl Disambiguation<Markup> for Group {
 impl Disambiguation<Markup> for Element {
     fn ref_ir(
         &self,
-        db: &impl IrDatabase,
+        db: &dyn IrDatabase,
         ctx: &RefContext<Markup>,
         state: &mut IrState,
         stack: Formatting,

--- a/crates/proc/src/disamb/names.rs
+++ b/crates/proc/src/disamb/names.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 impl Disambiguation<Markup> for Names {
     fn ref_ir(
         &self,
-        db: &impl IrDatabase,
+        db: &dyn IrDatabase,
         ctx: &RefContext<Markup>,
         state: &mut IrState,
         stack: Formatting,
@@ -164,7 +164,7 @@ impl Disambiguation<Markup> for Names {
 
 citeproc_db::intern_key!(pub DisambName);
 impl DisambName {
-    pub fn lookup(self, db: &impl IrDatabase) -> DisambNameData {
+    pub fn lookup(self, db: &dyn IrDatabase) -> DisambNameData {
         db.lookup_disamb_name(self)
     }
 }
@@ -187,7 +187,7 @@ impl DisambNameData {
     }
 
     /// This is used directly for *global name disambiguation*
-    pub(crate) fn single_name_edge(&self, db: &impl IrDatabase, stack: Formatting) -> Edge {
+    pub(crate) fn single_name_edge(&self, db: &dyn IrDatabase, stack: Formatting) -> Edge {
         let fmt = &db.get_formatter();
         let style = db.style();
         let builder = OneNameVar {
@@ -384,7 +384,7 @@ fn test_name_disamb_iter() {
 
 /// Original + expansions
 fn add_expanded_name_to_graph(
-    db: &impl IrDatabase,
+    db: &dyn IrDatabase,
     nfa: &mut Nfa,
     mut dn: DisambNameData,
     spot: NodeIndex,
@@ -416,7 +416,7 @@ impl NameVariantMatcher {
         self.0.contains(&edge)
     }
 
-    pub fn from_disamb_name(db: &impl IrDatabase, dn: DisambName) -> Self {
+    pub fn from_disamb_name(db: &dyn IrDatabase, dn: DisambName) -> Self {
         let style = db.style();
         let _fmt = &db.get_formatter();
         let rule = style.citation.givenname_disambiguation_rule;
@@ -437,7 +437,7 @@ impl NameVariantMatcher {
 
 /// Performs 'global name disambiguation'
 pub fn disambiguated_person_names(
-    db: &impl IrDatabase,
+    db: &dyn IrDatabase,
 ) -> Arc<FnvHashMap<DisambName, DisambNameData>> {
     let style = db.style();
     let rule = style.citation.givenname_disambiguation_rule;
@@ -613,7 +613,7 @@ where
             self.achieved_at = (count, self.name_counter);
         }
     }
-    pub fn rollback(&mut self, db: &impl IrDatabase, ctx: &CiteContext<'_, O>) {
+    pub fn rollback(&mut self, db: &dyn IrDatabase, ctx: &CiteContext<'_, O>) {
         let (_prev_best, at) = self.achieved_at;
         if self.name_counter.bump > at.bump {
             info!("{:?} rolling back to {:?} names", ctx.cite_id, at);
@@ -625,7 +625,7 @@ where
     }
 
     // returns false if couldn't add any more names
-    pub fn add_name(&mut self, db: &impl IrDatabase, ctx: &CiteContext<'_, O>) -> bool {
+    pub fn add_name(&mut self, db: &dyn IrDatabase, ctx: &CiteContext<'_, O>) -> bool {
         self.name_counter.bump += 1;
         match self.intermediate_custom(&ctx.format, ctx.position.0, ctx.sort_key.is_some(), Some(DisambPass::AddNames), None) {
             Some((new_ir, _)) => {

--- a/crates/proc/src/element.rs
+++ b/crates/proc/src/element.rs
@@ -10,7 +10,7 @@ where
 {
     fn intermediate(
         &self,
-        db: &impl IrDatabase,
+        db: &dyn IrDatabase,
         state: &mut IrState,
         ctx: &CiteContext<'c, O, I>,
     ) -> IrSum<O> {
@@ -26,7 +26,7 @@ where
 {
     fn intermediate(
         &self,
-        db: &impl IrDatabase,
+        db: &dyn IrDatabase,
         state: &mut IrState,
         ctx: &CiteContext<'c, O, I>,
     ) -> IrSum<O> {
@@ -57,7 +57,7 @@ where
 {
     fn intermediate(
         &self,
-        db: &impl IrDatabase,
+        db: &dyn IrDatabase,
         state: &mut IrState,
         ctx: &CiteContext<'c, O, I>,
     ) -> IrSum<O> {
@@ -244,18 +244,17 @@ impl YearSuffixHook {
     }
 }
 
-struct ProcWalker<'a, DB, O, I>
+struct ProcWalker<'a, O, I>
 where
-    DB: IrDatabase,
     O: OutputFormat,
     I: OutputFormat,
 {
-    db: &'a DB,
+    db: &'a dyn IrDatabase,
     state: IrState,
     ctx: &'a CiteContext<'a, O, I>,
 }
 
-impl<'a, DB: IrDatabase, O: OutputFormat, I: OutputFormat> StyleWalker for ProcWalker<'a, DB, O, I> {
+impl<'a, O: OutputFormat, I: OutputFormat> StyleWalker for ProcWalker<'a, O, I> {
     type Output = IrSum<O>;
     type Checker = CiteContext<'a, O, I>;
     fn get_checker(&self) -> Option<&Self::Checker> {

--- a/crates/proc/src/helpers.rs
+++ b/crates/proc/src/helpers.rs
@@ -12,7 +12,7 @@ use csl::Atom;
 use csl::{Affixes, DisplayMode, Element, Formatting};
 
 pub fn sequence_basic<'c, O, I>(
-    db: &impl IrDatabase,
+    db: &dyn IrDatabase,
     state: &mut IrState,
     ctx: &CiteContext<'c, O, I>,
     els: &[Element],
@@ -26,7 +26,7 @@ where
 
 
 pub fn sequence<'c, O, I>(
-    db: &impl IrDatabase,
+    db: &dyn IrDatabase,
     state: &mut IrState,
     ctx: &CiteContext<'c, O, I>,
     els: &[Element],
@@ -87,7 +87,7 @@ where
 }
 
 pub fn ref_sequence_basic<'c>(
-    db: &impl IrDatabase,
+    db: &dyn IrDatabase,
     state: &mut IrState,
     ctx: &RefContext<'c>,
     els: &[Element],
@@ -98,7 +98,7 @@ pub fn ref_sequence_basic<'c>(
 
 
 pub fn ref_sequence<'c>(
-    db: &impl IrDatabase,
+    db: &dyn IrDatabase,
     state: &mut IrState,
     ctx: &RefContext<'c, Markup>,
     els: &[Element],

--- a/crates/proc/src/ir.rs
+++ b/crates/proc/src/ir.rs
@@ -368,14 +368,22 @@ where
             (IR::Seq(s), IR::Seq(o)) if s == o => true,
             (IR::YearSuffix(s), IR::YearSuffix(o)) if s == o => true,
             (IR::ConditionalDisamb(a), IR::ConditionalDisamb(b)) => {
-                let aa = a.lock().unwrap();
-                let bb = b.lock().unwrap();
-                *aa == *bb
+                if Arc::ptr_eq(a, b) {
+                    true
+                } else {
+                    let aa = a.lock().unwrap();
+                    let bb = b.lock().unwrap();
+                    *aa == *bb
+                }
             }
             (IR::Name(self_nir), IR::Name(other_nir)) => {
-                let s = self_nir.lock().unwrap();
-                let o = other_nir.lock().unwrap();
-                *s == *o
+                if Arc::ptr_eq(self_nir, other_nir) {
+                    true
+                } else {
+                    let s = self_nir.lock().unwrap();
+                    let o = other_nir.lock().unwrap();
+                    *s == *o
+                }
             }
             _ => false,
         }

--- a/crates/proc/src/ir.rs
+++ b/crates/proc/src/ir.rs
@@ -298,11 +298,6 @@ pub struct IrNameCounter<O: OutputFormat> {
     pub group_vars: GroupVars,
 }
 
-#[derive(Debug, Clone)]
-pub struct RefIrNameCounter {
-    name_irs: Vec<RefNameIR>,
-}
-
 impl<O: OutputFormat> IrNameCounter<O> {
     pub fn count<I: OutputFormat>(&self, ctx: &CiteContext<'_, O, I>) -> u32 {
         self.name_irs
@@ -327,18 +322,22 @@ impl<O: OutputFormat> IrNameCounter<O> {
     }
 }
 
-impl RefIrNameCounter {
-    fn count(&self) -> u32 {
-        500
-    }
-    pub fn render_ref(&self, db: &dyn IrDatabase, ctx: &RefContext<'_, Markup>, stack: Formatting, piq: Option<bool>) -> (RefIR, GroupVars) {
-        let count = self.count();
-        let fmt = ctx.format;
-        let out = fmt.output_in_context(fmt.text_node(format!("{}", count), None), stack, piq);
-        let edge = db.edge(EdgeData::<Markup>::Output(out));
-        (RefIR::Edge(Some(edge)), GroupVars::Important)
-    }
-}
+// #[derive(Debug, Clone)]
+// pub struct RefIrNameCounter {
+//     name_irs: Vec<RefNameIR>,
+// }
+// impl RefIrNameCounter {
+//     fn count(&self) -> u32 {
+//         500
+//     }
+//     pub fn render_ref(&self, db: &dyn IrDatabase, ctx: &RefContext<'_, Markup>, stack: Formatting, piq: Option<bool>) -> (RefIR, GroupVars) {
+//         let count = self.count();
+//         let fmt = ctx.format;
+//         let out = fmt.output_in_context(fmt.text_node(format!("{}", count), None), stack, piq);
+//         let edge = db.edge(EdgeData::<Markup>::Output(out));
+//         (RefIR::Edge(Some(edge)), GroupVars::Important)
+//     }
+// }
 
 impl<O> IR<O>
 where

--- a/crates/proc/src/ir.rs
+++ b/crates/proc/src/ir.rs
@@ -123,7 +123,7 @@ pub struct RefIrSeq {
 }
 
 impl RefIR {
-    pub fn debug(&self, db: &impl IrDatabase) -> String {
+    pub fn debug(&self, db: &dyn IrDatabase) -> String {
         match self {
             RefIR::Edge(Some(e)) => format!("{:?}", db.lookup_edge(*e)),
             RefIR::Edge(None) => "None".into(),
@@ -331,7 +331,7 @@ impl RefIrNameCounter {
     fn count(&self) -> u32 {
         500
     }
-    pub fn render_ref(&self, db: &impl IrDatabase, ctx: &RefContext<'_, Markup>, stack: Formatting, piq: Option<bool>) -> (RefIR, GroupVars) {
+    pub fn render_ref(&self, db: &dyn IrDatabase, ctx: &RefContext<'_, Markup>, stack: Formatting, piq: Option<bool>) -> (RefIR, GroupVars) {
         let count = self.count();
         let fmt = ctx.format;
         let out = fmt.output_in_context(fmt.text_node(format!("{}", count), None), stack, piq);

--- a/crates/proc/src/ir/transforms.rs
+++ b/crates/proc/src/ir/transforms.rs
@@ -483,7 +483,7 @@ impl<O: OutputFormat> Unnamed3<O> {
 }
 
 pub fn group_and_collapse<O: OutputFormat<Output = String>>(
-    db: &impl IrDatabase,
+    db: &dyn IrDatabase,
     fmt: &Markup,
     delim: &str,
     collapse: Option<Collapse>,

--- a/crates/proc/src/ir/transforms.rs
+++ b/crates/proc/src/ir/transforms.rs
@@ -48,7 +48,8 @@ impl<O: OutputFormat> IR<O> {
 
 impl<O: OutputFormat> IR<O> {
     pub fn split_first_field(&mut self) {
-        if let Some(((first, gv), mut me)) = match self {
+        // Pull off the first field of self -> [first, ...rest]
+        if let Some(((first, gv), mut rest)) = match self {
             IR::Seq(seq) => if seq.contents.len() > 1 {
                 Some(seq.contents.remove(0))
             } else {
@@ -57,8 +58,10 @@ impl<O: OutputFormat> IR<O> {
             .and_then(|f| Some((f, mem::take(seq)))),
             _ => None,
         } {
-            me.display = Some(DisplayMode::RightInline);
-            let (afpre, afsuf) = me
+            rest.display = Some(DisplayMode::RightInline);
+
+            // Split the affixes into two sets with empty inside.
+            let (afpre, afsuf) = rest
                 .affixes
                 .map(|mine| {
                     (
@@ -73,38 +76,37 @@ impl<O: OutputFormat> IR<O> {
                     )
                 })
                 .unwrap_or((None, None));
-            mem::replace(
-                self,
-                IR::Seq(IrSeq {
-                    contents: vec![
-                        (
-                            IR::Seq(IrSeq {
-                                contents: vec![(first, gv)],
-                                display: Some(DisplayMode::LeftMargin),
-                                affixes: afpre,
-                                ..Default::default()
-                            }),
-                            gv,
-                        ),
-                        (
-                            IR::Seq(IrSeq {
-                                contents: me.contents,
-                                display: Some(DisplayMode::RightInline),
-                                affixes: afsuf,
-                                ..Default::default()
-                            }),
-                            GroupVars::Important,
-                        ),
-                    ],
-                    display: None,
-                    formatting: me.formatting,
-                    affixes: None,
-                    delimiter: me.delimiter.clone(),
-                    dropped_gv: None,
-                    quotes: me.quotes.clone(),
-                    text_case: me.text_case,
-                }),
-            );
+
+            // Replace with joined splits
+            *self = IR::Seq(IrSeq {
+                contents: vec![
+                    (
+                        IR::Seq(IrSeq {
+                            contents: vec![(first, gv)],
+                            display: Some(DisplayMode::LeftMargin),
+                            affixes: afpre,
+                            ..Default::default()
+                        }),
+                        gv,
+                    ),
+                    (
+                        IR::Seq(IrSeq {
+                            contents: rest.contents,
+                            display: Some(DisplayMode::RightInline),
+                            affixes: afsuf,
+                            ..Default::default()
+                        }),
+                        GroupVars::Important,
+                    ),
+                ],
+                display: None,
+                formatting: rest.formatting,
+                affixes: None,
+                delimiter: rest.delimiter.clone(),
+                dropped_gv: None,
+                quotes: rest.quotes.clone(),
+                text_case: rest.text_case,
+            });
         }
     }
 }
@@ -322,13 +324,6 @@ impl CnumIx {
             cnum: c,
             ix,
             force_single: false,
-        }
-    }
-    fn force_single(c: u32, ix: usize) -> Self {
-        CnumIx {
-            cnum: c,
-            ix,
-            force_single: true,
         }
     }
 }

--- a/crates/proc/src/ir/transforms.rs
+++ b/crates/proc/src/ir/transforms.rs
@@ -771,7 +771,7 @@ pub fn subsequent_author_substitute<O: OutputFormat>(
     sas: &str,
     sas_rule: SasRule,
 ) -> bool {
-    let mut pre = previous.lock().unwrap();
+    let pre = previous.lock().unwrap();
     let mut cur = current.lock().unwrap();
     let pre_tokens = pre.iter_bib_rendered_names(fmt);
     let pre_reduced = pre_tokens

--- a/crates/proc/src/lib.rs
+++ b/crates/proc/src/lib.rs
@@ -85,7 +85,7 @@ where
 {
     fn intermediate(
         &self,
-        db: &impl IrDatabase,
+        db: &dyn IrDatabase,
         state: &mut IrState,
         ctx: &CiteContext<'c, O, I>,
     ) -> IrSum<O>;

--- a/crates/proc/src/names.rs
+++ b/crates/proc/src/names.rs
@@ -143,6 +143,7 @@ pub fn to_individual_name_irs<'a, O: OutputFormat, I: OutputFormat>(
     if is_editor_translator && !editortranslator_term_empty {
         let ed_val = refr.name.get(&NameVariable::Editor);
         let tr_val = refr.name.get(&NameVariable::Translator);
+        let _x = 5;
         if let (Some(ed), Some(tr)) = (ed_val, tr_val) {
             // identical
             if ed == tr {
@@ -467,7 +468,7 @@ impl<'c, O: OutputFormat> NameIR<O> {
                 }
                 NameTokenBuilt::Ratchet(DisambNameRatchet::Person(pn)) => {
                     runner.name_el = &pn.data.el;
-                    let mut ret = runner.render_person_name(&pn.data.value, !pn.data.primary);
+                    let ret = runner.render_person_name(&pn.data.value, !pn.data.primary);
                     runner.name_el = &names_inheritance.name;
                     Some(maybe_subst(ret))
                 }
@@ -945,9 +946,6 @@ impl<'a, O: OutputFormat> OneNameVar<'a, O> {
                         .suffix
                         .as_ref()
                         .filter(|_| token == NamePartToken::FamilyFull);
-                    let string = String::with_capacity(
-                        fam.len() + 2 + dp.map_or(0, |x| x.len()) + ndp.map_or(0, |x| x.len()),
-                    );
                     let mut parts = Vec::new();
                     if let Some(dp) = dp {
                         let string = dp.clone();

--- a/crates/proc/src/names.rs
+++ b/crates/proc/src/names.rs
@@ -855,7 +855,6 @@ impl<'a, O: OutputFormat> OneNameVar<'a, O> {
             None => fmt.text_node(s.into(), None),
             Some(ref part) => {
                 let NamePart {
-                    // TODO: need to set text case on name parts.
                     text_case,
                     formatting,
                     // Don't apply affixes here; that has to be done separately for the weirdo

--- a/crates/proc/src/number.rs
+++ b/crates/proc/src/number.rs
@@ -134,7 +134,7 @@ fn tokens_to_string(
                 None
             }
             Hyphen => {
-                let mut hyphen = get_hyphen(locale, variable);
+                let hyphen = get_hyphen(locale, variable);
                 s.push_str(hyphen);
                 match state {
                     Some(NumBefore::SeenNum(i)) => Some(NumBefore::SeenNumHyphen(i)),

--- a/crates/wasm/js-demo/js/Document.ts
+++ b/crates/wasm/js-demo/js/Document.ts
@@ -1,5 +1,5 @@
-import { Reference, Cite, Cluster, ClusterPosition, Driver, UpdateSummary, Lifecycle } from '../../pkg';
-import { produce, immerable, Draft, IProduce } from 'immer';
+import { Reference, Cite, Cluster, ClusterPosition, Driver, UpdateSummary, IncludeUncited } from '../../pkg';
+import { produce, immerable, Draft } from 'immer';
 
 export type ClusterId = number;
 export type CiteId = number;
@@ -95,13 +95,13 @@ export class Document {
 
     /** The internal document model */
     public clusters: Cluster[];
+    public includeUncited: IncludeUncited = "None";
 
     public rendered: RenderedDocument;
 
     private refCounts: RefCounter;
 
     private nextClusterId = 100;
-    private nextCiteId = 100;
 
     constructor(clusters: Cluster[], driver?: Driver) {
         this.refCounts = new RefCounter(
@@ -130,6 +130,7 @@ export class Document {
         this.driver = driver;
         driver.initClusters(this.clusters);
         driver.setClusterOrder(this.clusterPositions());
+        driver.includeUncited(this.includeUncited);
         this.rendered = new RenderedDocument(this.clusters, this.clusterPositions(), driver);
         // Drain the update queue, because we know we're up to date
         this.driver.drain();
@@ -159,6 +160,16 @@ export class Document {
     clusterPositions(): Array<ClusterPosition> {
         // Simple but good for a demo: one note number per cluster.
         return this.clusters.map((c, i) => ({ id: c.id, note: i + 1 }));
+    }
+
+    ///////////////////
+    // Uncited items //
+    ///////////////////
+
+
+    setIncludeUncited(uncited: IncludeUncited) {
+        this.includeUncited = uncited;
+        this.driver.includeUncited(this.includeUncited);
     }
 
     //////////////

--- a/crates/wasm/js-demo/js/DocumentEditor.tsx
+++ b/crates/wasm/js-demo/js/DocumentEditor.tsx
@@ -1,6 +1,6 @@
 import { Document, RenderedDocument } from './Document';
 import React, { useState, useEffect, useCallback } from 'react';
-import { Cluster, Cite } from '../../pkg';
+import { Cluster, Cite, IncludeUncited } from '../../pkg';
 
 import './bibliography.css';
 
@@ -9,6 +9,7 @@ const btnStyle = {
 }
 
 export const DocumentEditor = ({document, onChange}: { document: Document; onChange: (d: Document) => void }) => {
+  let [csvIncl, setCsvIncl] = useState("");
     const insertCluster = (before: number) => {
         let neu = document.produce(draft => {
             let cl = draft.createCluster([{ id: 'citekey' }]);
@@ -29,6 +30,27 @@ export const DocumentEditor = ({document, onChange}: { document: Document; onCha
     return <>
         { editors }
         <button style={btnStyle} onClick={() => insertCluster(null)} >+cluster</button>
+          <div>
+            Include uncited items?
+              <input style={{width: 400}} type="text" value={csvIncl} onChange={(ev) => {
+                let val = ev.target.value;
+                let unc: IncludeUncited = "None";
+                let joined = val;
+                if (val == "All") {
+                  unc = "All";
+                } else if (val == "None") {
+                  unc = "None";
+                } else if (val == "") {
+                  unc = "None";
+                } else {
+                  let arr = ev.target.value.split(/, */);
+                  unc = { Specific: arr };
+                  joined = arr.join(", ");
+                }
+                document.produce(d => d.setIncludeUncited(unc));
+                setCsvIncl(joined);
+              }} placeholder="None (default), All, or a comma-separated list of citekeys"/>
+        </div>
         <DocumentViewer renderedDocument={document.rendered} />
     </>;
 };

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -359,7 +359,7 @@ export type Cite<Affix = string> = {
     prefix?: Affix;
     suffix?: Affix;
     suppression?: "InText" | "Rest" | null;
-} & CiteLocator;
+} & Partial<CiteLocator>;
 
 export type ClusterNumber = {
     note: number | [number, number]


### PR DESCRIPTION
In sum:

```javascript
driver.includeUncited("None"); // Default
driver.includeUncited("All");
driver.includeUncited({ Specific: ["citekeyA", "citekeyB"] });
```

If a reference, known to the driver, is not cited in any of the clusters in the document, it can still be included in the bibliography if it matches the filter set by `includeUncited()`.

This has been tested especially in the context of disambiguating using those uncited items. It lacks an actual test suite to confirm that, but the matter is almost entirely whether those items participate or not.

Also:

- Actually creates "ghost cites" of uncited items for disambiguation
- Finally allocates year-suffixes in bibliography order, per the spec, which 
  can be different from cited order
- Uses pristine ghost cites, even for cited items, when forming year-suffix 
  groups. Because "ibid" references can match more items' DFAs than they 
  should. See that "Alloc year suffixes" commit for details.
- Workaround for some mutex issues that I have now solved (subsequent PR)
