### PR TITLE
Preview citation cluster

### DIFF
--- a/crates/citeproc/src/api.rs
+++ b/crates/citeproc/src/api.rs
@@ -8,6 +8,7 @@
 
 use citeproc_io::output::{markup::Markup, OutputFormat};
 use citeproc_io::ClusterId;
+use super::Processor;
 use citeproc_proc::db::IrDatabase;
 use std::sync::Arc;
 use std::str::FromStr;
@@ -76,7 +77,7 @@ pub struct UpdateSummary<O: OutputFormat = Markup> {
 }
 
 impl UpdateSummary {
-    pub fn summarize(db: &dyn IrDatabase, updates: &[DocUpdate]) -> Self {
+    pub fn summarize(db: &Processor, updates: &[DocUpdate]) -> Self {
         let ids = updates.iter().map(|&u| match u {
             DocUpdate::Cluster(x) => x,
         });
@@ -86,7 +87,13 @@ impl UpdateSummary {
         }
         let mut clusters = Vec::with_capacity(set.len());
         for id in set {
-            clusters.push((id, db.built_cluster(id)));
+            if id == 0 {
+                // It's a dummy value for preview_citation_cluster.
+                continue;
+            }
+            if let Some(output) = db.get_cluster(id) {
+                clusters.push((id, output));
+            }
         }
         UpdateSummary {
             clusters,

--- a/crates/citeproc/src/lib.rs
+++ b/crates/citeproc/src/lib.rs
@@ -16,11 +16,11 @@ pub(crate) mod api;
 mod test;
 
 pub use self::api::{DocUpdate, UpdateSummary, IncludeUncited, SupportedFormat};
-pub use self::processor::{ErrorKind, Processor};
+pub use self::processor::{ErrorKind, Processor, PreviewPosition};
 
 pub mod prelude {
     pub use crate::api::{DocUpdate, UpdateSummary, IncludeUncited, SupportedFormat};
-    pub use crate::processor::Processor;
+    pub use crate::processor::{Processor, PreviewPosition};
     pub use citeproc_db::{
         CiteDatabase, CiteId, LocaleDatabase, LocaleFetchError, LocaleFetcher, StyleDatabase,
     };

--- a/crates/proc/src/db.rs
+++ b/crates/proc/src/db.rs
@@ -886,6 +886,16 @@ fn built_cluster(
     Arc::new(string)
 }
 
+pub fn built_cluster_preview(
+    db: &dyn IrDatabase,
+    cluster_id: ClusterId,
+    formatter: &Markup,
+) -> Arc<<Markup as OutputFormat>::Output> {
+    let build = built_cluster_before_output(db, cluster_id);
+    let string = formatter.output(build, get_piq(db));
+    Arc::new(string)
+}
+
 pub fn built_cluster_before_output(
     db: &dyn IrDatabase,
     cluster_id: ClusterId,

--- a/crates/test-utils/src/humans.rs
+++ b/crates/test-utils/src/humans.rs
@@ -39,7 +39,7 @@ impl CitationItem {
             CitationItem::Map { cites } => cites,
         };
         let cites = v.iter().map(CiteprocJsCite::to_cite).collect();
-        Cluster { id: index, cites }
+        Cluster { id: index + 1, cites }
     }
 }
 
@@ -252,7 +252,7 @@ impl JsExecutor<'_> {
             cluster_ids_mapping: HashMap::new(),
             current_note_numbers: HashMap::new(),
             proc,
-            next_id: 0,
+            next_id: 1,
         }
     }
     fn get_id(&mut self, string_id: &str) -> ClusterId {

--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -107,7 +107,7 @@ impl TestCase {
             let fet = Arc::new(Filesystem::project_dirs());
             Processor::new(&csl, fet, true, format.0).expect("could not construct processor")
         };
-        processor.set_references(input.clone());
+        processor.reset_references(input.clone());
         Warmup::maximum().execute(&mut processor);
         TestCase {
             mode,

--- a/crates/wasm/js-demo/js/Document.ts
+++ b/crates/wasm/js-demo/js/Document.ts
@@ -134,6 +134,7 @@ export class Document {
         this.rendered = new RenderedDocument(this.clusters, this.clusterPositions(), driver);
         // Drain the update queue, because we know we're up to date
         this.driver.drain();
+        console.log(this.driver);
     }
 
     /** Warning: Does not free the old driver. You should have kept a copy to call free() on. */

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -210,12 +210,13 @@ impl Driver {
         &mut self,
         cites: Box<[JsValue]>,
         positions: Box<[JsValue]>,
+        format: &str,
     ) -> Result<JsValue, JsValue> {
         let cites: Vec<Cite<Markup>> = utils::read_js_array(cites)?;
         let positions: Vec<ClusterPosition> = utils::read_js_array(positions)?;
         let mut eng = self.engine.borrow_mut();
         let preview =
-            eng.preview_citation_cluster(cites, PreviewPosition::MarkWithZero(&positions));
+            eng.preview_citation_cluster(cites, PreviewPosition::MarkWithZero(&positions), SupportedFormat::from_str(format).ok());
         preview
             .map_err(|e| JsError::new(&e.to_string()))
             .and_then(|b| JsValue::from_serde(&b).map_err(|e| JsError::new(&e.to_string())))

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -197,24 +197,30 @@ impl Driver {
             .and_then(|b| JsValue::from_serde(&b).map_err(|e| JsError::new(e.description())))?)
     }
 
-    /// Returns the formatted citation cluster for `cluster_id`.
+    /// Previews a formatted citation cluster, in a particular position.
     ///
-    /// Prefer `batchedUpdates` to avoid serializing unchanged clusters on every edit. This is
-    /// still useful for initialization.
+    /// - `cites`: The cites to go in the cluster
+    /// - `positions`: An array of `ClusterPosition`s as in set_cluster_order, but with a single
+    ///   cluster's id set to zero. The cluster with id=0 is the position to preview the cite. It
+    ///   can replace another cluster, or be inserted before/after/between existing clusters, in
+    ///   any location you can think of.
+    ///
     #[wasm_bindgen(js_name = "previewCitationCluster")]
-    pub fn preview_citation_cluster(&mut self, cites: Box<[JsValue]>, pieces: Box<[JsValue]>) -> Result<JsValue, JsValue> {
+    pub fn preview_citation_cluster(
+        &mut self,
+        cites: Box<[JsValue]>,
+        positions: Box<[JsValue]>,
+    ) -> Result<JsValue, JsValue> {
         let cites: Vec<Cite<Markup>> = utils::read_js_array(cites)?;
-        let positions: Vec<ClusterPosition> = utils::read_js_array(pieces)?;
+        let positions: Vec<ClusterPosition> = utils::read_js_array(positions)?;
         let mut eng = self.engine.borrow_mut();
-        let preview = eng.preview_citation_cluster(cites, PreviewPosition::MarkWithZero(&positions));
+        let preview =
+            eng.preview_citation_cluster(cites, PreviewPosition::MarkWithZero(&positions));
         preview
-            .map_err(|e| {
-                JsError::new(&e.to_string())
-            })
+            .map_err(|e| JsError::new(&e.to_string()))
             .and_then(|b| JsValue::from_serde(&b).map_err(|e| JsError::new(&e.to_string())))
             .map_err(|e| e.into())
     }
-
 
     #[wasm_bindgen(js_name = "makeBibliography")]
     pub fn full_bibliography(&self) -> Result<JsValue, JsValue> {
@@ -278,10 +284,10 @@ impl Driver {
     ///
     /// May error without having set_cluster_ids, but with some set_cluster_note_number-s executed.
     #[wasm_bindgen(js_name = "setClusterOrder")]
-    pub fn set_cluster_order(&mut self, pieces: Box<[JsValue]>) -> Result<(), JsValue> {
-        let pieces: Vec<ClusterPosition> = utils::read_js_array(pieces)?;
+    pub fn set_cluster_order(&mut self, positions: Box<[JsValue]>) -> Result<(), JsValue> {
+        let positions: Vec<ClusterPosition> = utils::read_js_array(positions)?;
         let mut eng = self.engine.borrow_mut();
-        eng.set_cluster_order(&pieces)
+        eng.set_cluster_order(&positions)
             .map_err(|e| ErrorPlaceholder::throw(&format!("{:?}", e)))?;
         Ok(())
     }

--- a/crates/wasm/src/utils.rs
+++ b/crates/wasm/src/utils.rs
@@ -30,11 +30,14 @@ cfg_if! {
 cfg_if! {
     if #[cfg(feature = "console")] {
         pub fn init_log() {
+            use log::LevelFilter;
             fern::Dispatch::new()
-                .level(log::LevelFilter::Warn)
-                .level_for("salsa", log::LevelFilter::Info)
-                .level_for("salsa::derived", log::LevelFilter::Warn)
-                .level_for("html5ever", log::LevelFilter::Off)
+                .level(LevelFilter::Warn)
+                .level_for("citeproc_proc::db", LevelFilter::Info)
+                // .level_for("citeproc_proc::ir", LevelFilter::Info)
+                .level_for("salsa", LevelFilter::Warn)
+                .level_for("salsa::derived", LevelFilter::Warn)
+                .level_for("html5ever", LevelFilter::Off)
                 .format(|out, message, record| {
                     out.finish(format_args!(
                         "[{}][{}] {}",


### PR DESCRIPTION
Adds a previewCitationCluster API, named after the similar method in citeproc-js.

From the draft README:

---

> ### Preview citation clusters
>
> Sometimes, a user wants to see how a cluster will look while they are editing it, before confirming the change.
> 
> ```javascript
> let cites = [ { id: "citekey", locator: "45" }, { ... } ];
> let positions = [ ... before, { id: 0, note: 34 }, ... after ];
> let preview = driver.previewCitationCluster(cites, positions, "html");
> ```
>
> The positions array is exactly like a call to `setClusterOrder`, except exactly  one of the positions has an id of 0. This could either:
>
> - Replace an existing cluster's position, and preview a cluster replacement; or
> - Represent the position a cluster is hypothetically inserted.
>
> If you passed only one position, it would be like previewing an operation like "delete the entire document and replace it with this one cluster". **That would mean you would never see "ibid" in a preview.** So for maximum utility, assemble the positions array as you would a call to `setClusterOrder` with exactly the operation you're previewing applied.


