### PR TITLE
Remove unclear setReferences, replace with insertReferences + resetReferences

### DIFF
--- a/crates/citeproc/benches/some.rs
+++ b/crates/citeproc/benches/some.rs
@@ -89,7 +89,7 @@ fn invalidate_rebuild_cluster(proc: &mut Processor, id: u32, cite_id: CiteId) ->
 
 fn bench_build_cluster(b: &mut Bencher, style: &str) {
     let mut proc = Processor::new(style, fetcher(), false, SupportedFormat::Html).unwrap();
-    proc.set_references(vec![common_reference(1)]);
+    proc.insert_reference(common_reference(1));
     let cite_id = basic_cluster_get_cite_id(&mut proc, 1, "id_1");
     proc.set_cluster_order(&[ClusterPosition { id: 1, note: Some(1) }]).unwrap();
     b.iter(move || invalidate_rebuild_cluster(&mut proc, 1, cite_id));

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -179,7 +179,7 @@ fn main() {
 
     // if let Some(_) = matches.subcommand_matches("disamb-index") {
     //     let mut db = Processor::new(filesystem_fetcher);
-    //     db.set_references(refs);
+    //     db.insert_references(refs);
     //     for (tok, ids) in db.inverted_index().iter() {
     //         // if ids.len() > 1 {
     //         let token = tok.clone();
@@ -211,7 +211,7 @@ fn main() {
                     note_number: 1,
                     cites: vec![citeproc::input::Cite::basic(key)],
                 }]);
-                db.set_references(refs);
+                db.inssert_references(refs);
 
                 let inlines = db.get_cluster(0).to_vec();
 
@@ -264,7 +264,7 @@ fn do_pandoc() {
     match Processor::new(&text, Arc::new(Filesystem::default()), false) {
         Ok(mut db) => {
             if let Some(library_path) = pandoc_meta_str(&doc, "bibliography") {
-                db.set_references(expect_refs(library_path));
+                db.reset_references(expect_refs(library_path));
             }
             db.init_clusters(pandoc::get_clusters(&mut doc));
             db.compute();

--- a/crates/proc/src/disamb/test.rs
+++ b/crates/proc/src/disamb/test.rs
@@ -150,7 +150,7 @@ fn test() {
 
     use citeproc_io::{Cite, Cluster, IntraNote};
 
-    db.set_references(vec![refr, refr2]);
+    db.insert_references(vec![refr, refr2]);
     let cluster = Cluster {
         id: 1,
         cites: vec![Cite::basic("ref_id")],

--- a/crates/proc/src/sort.rs
+++ b/crates/proc/src/sort.rs
@@ -352,7 +352,7 @@ fn test_date_as_macro_strip_delims() {
         DateVariable::Issued,
         DateOrRange::Single(Date::new(2000, 1, 1)),
     );
-    db.set_references(vec![refr]);
+    db.insert_reference(refr);
     db.set_style_text(r#"<?xml version="1.0" encoding="utf-8"?>
         <style version="1.0" class="note">
            <macro name="year-date">

--- a/crates/proc/src/test.rs
+++ b/crates/proc/src/test.rs
@@ -104,7 +104,7 @@ impl MockProcessor {
         self.set_cluster_ids(Arc::new(cluster_ids));
     }
 
-    pub fn set_references(&mut self, refs: Vec<Reference>) {
+    pub fn insert_references(&mut self, refs: Vec<Reference>) {
         let keys: HashSet<Atom> = refs.iter().map(|r| r.id.clone()).collect();
         for r in refs {
             self.set_reference_input(r.id.clone(), Arc::new(r));

--- a/crates/test-utils/src/toml.rs
+++ b/crates/test-utils/src/toml.rs
@@ -98,7 +98,7 @@ impl TomlTestCase {
         let mut proc =
             Processor::new(&self.style.csl, fet, true).expect("could not construct processor");
 
-        proc.set_references(self.references.clone());
+        proc.reset_references(self.references.clone());
         "".into()
         // Because citeproc-rs is a bit keen to escape things
         // Slashes are fine if they're not next to angle braces

--- a/crates/wasm/index.html
+++ b/crates/wasm/index.html
@@ -68,7 +68,7 @@
         }
 
         console.log("--- Successfully loaded wasm driver. You can now use it. ---")
-        driver.setReferences([{id: "citekey", title: "Hello", language: 'fr-FR'}]);
+        driver.insertReferences([{id: "citekey", title: "Hello", language: 'fr-FR'}]);
         driver.initClusters([{id: 1, cites: [{id: "citekey"}]}]);
         driver.setClusterOrder([ {id: 1} ]);
         await driver.fetchAll();

--- a/crates/wasm/js-demo/js/App.tsx
+++ b/crates/wasm/js-demo/js/App.tsx
@@ -133,18 +133,18 @@ async function loadEditor() {
     // Removes failed expectation of immediate response compared to lazily loading it.
     await import('../../pkg');
 
-    const StyleEditor = ({style, setStyle, setReferences} : {
+    const StyleEditor = ({style, setStyle, resetReferences} : {
         inFlight: boolean,
         style: string,
         setStyle: React.Dispatch<string>,
-        setReferences: (rs: Reference[]) => void;
+        resetReferences: (rs: Reference[]) => void;
     }) => {
         const [refsText, setRefsText] = useState(JSON.stringify(initialReferences, null, 2));
 
         const parseRefs = () => {
             try {
                 let refs = JSON.parse(refsText);
-                setReferences(refs);
+                resetReferences(refs);
             } catch (e) {
                 console.error("could not parse references json", e);
             }
@@ -243,7 +243,7 @@ const App = () => {
                     Test driver for <code>citeproc-wasm</code>
                 </a>
             </header>
-            <AsyncEditor style={style} setStyle={setStyle} inFlight={inFlight} setReferences={resetReferences} />
+            <AsyncEditor style={style} setStyle={setStyle} inFlight={inFlight} resetReferences={resetReferences} />
             <div  style={{display: 'flex'}}>
                 <section style={{flexGrow: 1}}>
                     <Results style={style} driver={driver} />

--- a/crates/wasm/js-demo/js/useDocument.ts
+++ b/crates/wasm/js-demo/js/useDocument.ts
@@ -48,12 +48,12 @@ export const useDocument = (initialStyle: string, initialReferences: Reference[]
         const { Driver: CreateDriver } = await import('../../pkg');
         let d: Result<Driver, any> = Result.from(() => {
             let d = CreateDriver.new(style, fetcher, "html");
-            d.setReferences(references);
+            d.resetReferences(references);
             return d;
         });
         if (d.is_ok()) {
             let newDriver = d.unwrap();
-            newDriver.setReferences(references);
+            newDriver.resetReferences(references);
             await flightFetcher(newDriver);
         }
         setDriver(d);
@@ -94,7 +94,7 @@ export const useDocument = (initialStyle: string, initialReferences: Reference[]
         setReferences(refs);
         if (driver.is_ok()) {
             let d = driver.unwrap();
-            d.setReferences(refs);
+            d.resetReferences(refs);
             await flightFetcher(d);
             setDocument(document.map(doc => doc.selfUpdate()));
         }
@@ -110,7 +110,7 @@ export const useDocument = (initialStyle: string, initialReferences: Reference[]
                 neu[i] = ref;
             }
         }
-        driver.tap(d => d.setReferences(refs));
+        driver.tap(d => d.insertReferences(refs));
         setReferences(neu);
         if (driver.is_ok()) {
             let d = driver.unwrap();
@@ -169,7 +169,7 @@ class _ExampleManager implements Lifecycle {
         // must be async imported to use
         // let newDriver = Driver.new(styleText, this);
         let newDriver = undefined as Driver;
-        newDriver.setReferences(this.references);
+        newDriver.resetReferences(this.references);
         newDriver.initClusters(this.clusters);
         // wait for any locales to come back
         await newDriver.fetchAll();
@@ -196,7 +196,7 @@ class _ExampleManager implements Lifecycle {
     async resetReferences(refs: Reference[]) {
         this.references = refs;
         if (this.driver) {
-            this.driver.setReferences(refs);
+            this.driver.resetReferences(refs);
             await this.driver.fetchAll();
             this.update();
         }
@@ -218,7 +218,7 @@ class _ExampleManager implements Lifecycle {
             } else {
                 neu[i] = ref;
             }
-            this.driver && this.driver.setReferences(refs);
+            this.driver && this.driver.resetReferences(refs);
         }
         this.references = neu;
         if (this.driver) {

--- a/crates/wasm/node-tryout/index.js
+++ b/crates/wasm/node-tryout/index.js
@@ -35,7 +35,7 @@ let prom = async () => {
   try {
     let fetcher = new Fetcher();
     let driver = Driver.new(style, fetcher, "html");
-    driver.setReferences([
+    driver.insertReferences([
       {
         id: 'citekey',
         type: 'book',

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -86,8 +86,8 @@ impl Driver {
 
     /// Inserts or overwrites references as a batch operation.
     /// This **will not** delete references that are not in the provided list.
-    #[wasm_bindgen(js_name = "setReferences")]
-    pub fn set_references(&mut self, refs: Box<[JsValue]>) -> Result<(), JsValue> {
+    #[wasm_bindgen(js_name = "insertReferences")]
+    pub fn insert_references(&mut self, refs: Box<[JsValue]>) -> Result<(), JsValue> {
         let refs = utils::read_js_array(refs)?;
         self.engine.borrow_mut().extend_references(refs);
         Ok(())


### PR DESCRIPTION
This was started in #68, it turns out. The terminology is updated to be 
consistent, especially important for uncited items:

- Reset will wipe all refs, replace the list.
- Insert will overwrite if necessary and otherwise insert.

