### PR TITLE
Eliminate Arc<Mutex<T>> in IR, using indextree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,7 +287,7 @@ dependencies = [
  "csl",
  "env_logger 0.7.1",
  "fnv",
- "generational-arena",
+ "indextree",
  "itertools",
  "lazy_static",
  "log",
@@ -703,15 +703,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generational-arena"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "675c9623fbcdb4b402176db720bf5d95883a36303703ed1bd3a03482382f735a"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -797,6 +788,12 @@ checksum = "712d7b3ea5827fcb9d4fda14bf4da5f136f0db2ae9c8f4bd4e2d1c6fde4e6db2"
 dependencies = [
  "autocfg 0.1.7",
 ]
+
+[[package]]
+name = "indextree"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990980c3d268c9b99df35e813eca2b8d1ee08606f6d2bb325edbd0b0c68f9ffe"
 
 [[package]]
 name = "insta"

--- a/crates/citeproc/benches/some.rs
+++ b/crates/citeproc/benches/some.rs
@@ -68,15 +68,24 @@ fn basic_cluster_get_cite_id(proc: &mut Processor, cluster_id: u32, id: &str) ->
         cites: vec![Cite::basic(id)],
     };
     proc.insert_cluster(cluster);
-    let id = proc.cluster_cites(cluster_id).iter().cloned().nth(0).unwrap();
+    let id = proc
+        .cluster_cites(cluster_id)
+        .iter()
+        .cloned()
+        .nth(0)
+        .unwrap();
     id
 }
 
 fn invalidate_rebuild_cluster(proc: &mut Processor, id: u32, cite_id: CiteId) -> Arc<String> {
     use citeproc_proc::db;
     db::IrGen0Query.in_db_mut(proc).invalidate(&cite_id);
-    db::IrGen2AddGivenNameQuery.in_db_mut(proc).invalidate(&cite_id);
-    db::IrFullyDisambiguatedQuery.in_db_mut(proc).invalidate(&cite_id);
+    db::IrGen2AddGivenNameQuery
+        .in_db_mut(proc)
+        .invalidate(&cite_id);
+    db::IrFullyDisambiguatedQuery
+        .in_db_mut(proc)
+        .invalidate(&cite_id);
     db::BuiltClusterQuery.in_db_mut(proc).invalidate(&id);
     proc.built_cluster(id)
 }
@@ -85,15 +94,23 @@ fn bench_build_cluster(b: &mut Bencher, style: &str) {
     let mut proc = Processor::new(style, fetcher(), false, SupportedFormat::Html).unwrap();
     proc.insert_reference(common_reference(1));
     let cite_id = basic_cluster_get_cite_id(&mut proc, 1, "id_1");
-    proc.set_cluster_order(&[ClusterPosition { id: 1, note: Some(1) }]).unwrap();
+    proc.set_cluster_order(&[ClusterPosition {
+        id: 1,
+        note: Some(1),
+    }])
+    .unwrap();
     b.iter(move || invalidate_rebuild_cluster(&mut proc, 1, cite_id));
     // b.iter_batched_ref(make, |proc| proc.built_cluster(1), BatchSize::SmallInput)
 }
 
 fn bench_clusters(c: &mut Criterion) {
     env_logger::init();
-    c.bench_function("Processor::built_cluster(AGLC)", |b| bench_build_cluster(b, AGLC));
-    c.bench_function("Processor::built_cluster(APA)", |b| bench_build_cluster(b, APA));
+    c.bench_function("Processor::built_cluster(AGLC)", |b| {
+        bench_build_cluster(b, AGLC)
+    });
+    c.bench_function("Processor::built_cluster(APA)", |b| {
+        bench_build_cluster(b, APA)
+    });
 }
 
 criterion_group!(clusters, bench_clusters);

--- a/crates/citeproc/src/api.rs
+++ b/crates/citeproc/src/api.rs
@@ -6,12 +6,12 @@
 
 #![allow(dead_code)]
 
+use super::Processor;
 use citeproc_io::output::{markup::Markup, OutputFormat};
 use citeproc_io::ClusterId;
-use super::Processor;
 use citeproc_proc::db::IrDatabase;
-use std::sync::Arc;
 use std::str::FromStr;
+use std::sync::Arc;
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub enum DocUpdate {
@@ -149,4 +149,3 @@ impl<'de> serde::de::Deserialize<'de> for SupportedFormat {
             .map_err(|()| DeError::custom(format!("unknown format {}", s.as_str())))
     }
 }
-

--- a/crates/citeproc/src/lib.rs
+++ b/crates/citeproc/src/lib.rs
@@ -9,23 +9,25 @@ extern crate serde_derive;
 // #[macro_use]
 // extern crate log;
 
-pub(crate) mod processor;
 pub(crate) mod api;
+pub(crate) mod processor;
 
 #[cfg(test)]
 mod test;
 
-pub use self::api::{DocUpdate, UpdateSummary, IncludeUncited, SupportedFormat};
-pub use self::processor::{ErrorKind, Processor, PreviewPosition};
+pub use self::api::{DocUpdate, IncludeUncited, SupportedFormat, UpdateSummary};
+pub use self::processor::{ErrorKind, PreviewPosition, Processor};
 
 pub mod prelude {
-    pub use crate::api::{DocUpdate, UpdateSummary, IncludeUncited, SupportedFormat};
-    pub use crate::processor::{Processor, PreviewPosition};
+    pub use crate::api::{DocUpdate, IncludeUncited, SupportedFormat, UpdateSummary};
+    pub use crate::processor::{PreviewPosition, Processor};
     pub use citeproc_db::{
         CiteDatabase, CiteId, LocaleDatabase, LocaleFetchError, LocaleFetcher, StyleDatabase,
     };
     pub use citeproc_io::output::{markup::Markup, OutputFormat};
-    pub use citeproc_io::{Cite, Cluster, ClusterId, ClusterNumber, IntraNote, Reference, ClusterPosition};
+    pub use citeproc_io::{
+        Cite, Cluster, ClusterId, ClusterNumber, ClusterPosition, IntraNote, Reference,
+    };
     pub use citeproc_proc::db::{HasFormatter, IrDatabase};
     pub use csl::Atom;
 }

--- a/crates/citeproc/src/processor.rs
+++ b/crates/citeproc/src/processor.rs
@@ -541,10 +541,7 @@ pub enum PreviewPosition<'a> {
 }
 
 impl Processor {
-    fn save_cluster_state(
-        &self,
-        relevant_cluster: Option<ClusterId>,
-    ) -> ClusterState {
+    fn save_cluster_state(&self, relevant_cluster: Option<ClusterId>) -> ClusterState {
         let cluster_ids = self.cluster_ids();
         let relevant_one = relevant_cluster
             .filter(|rc| cluster_ids.contains(rc))
@@ -612,7 +609,7 @@ impl Processor {
             }
             PreviewPosition::MarkWithZero(positions) => {
                 if positions.iter().filter(|pos| pos.id == 0).count() != 1 {
-                    return Err(ErrorKind::DidNotSupplyZeroPosition)
+                    return Err(ErrorKind::DidNotSupplyZeroPosition);
                 }
                 let mut vec = Vec::new();
                 // Save state first so we don't clobber its cluster_ids store
@@ -624,7 +621,9 @@ impl Processor {
             }
         };
         self.insert_cluster(Cluster { id, cites });
-        let formatter = format.map(markup_supported).unwrap_or_else(|| self.formatter.clone());
+        let formatter = format
+            .map(markup_supported)
+            .unwrap_or_else(|| self.formatter.clone());
         let markup = citeproc_proc::db::built_cluster_preview(self, id, &formatter);
         self.restore_cluster_state(state);
         Ok(markup)
@@ -637,9 +636,7 @@ pub enum ErrorKind {
         "set_cluster_order called with a note number {0} that was out of order (e.g. [1, 2, 3, 1])"
     )]
     NonMonotonicNoteNumber(u32),
-    #[error(
-        "call to preview_citation_cluster must provide exactly one id=0 position"
-    )]
+    #[error("call to preview_citation_cluster must provide exactly one id=0 position")]
     DidNotSupplyZeroPosition,
 }
 

--- a/crates/citeproc/src/test.rs
+++ b/crates/citeproc/src/test.rs
@@ -7,13 +7,16 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use csl::*;
 use crate::prelude::*;
+use csl::*;
 
 macro_rules! assert_cluster {
     ($arcstring:expr, $optstr:expr) => {
         let built = $arcstring;
-        assert_eq!(built.as_deref().map(|string_ref| string_ref.as_str()), $optstr);
+        assert_eq!(
+            built.as_deref().map(|string_ref| string_ref.as_str()),
+            $optstr
+        );
     };
 }
 
@@ -206,9 +209,18 @@ mod preview {
         let mut db = mk_db();
         let cites = vec![Cite::basic("one")];
         let positions = &[
-            ClusterPosition { id: 1, note: Some(1) },
-            ClusterPosition { id: 2, note: Some(2) },
-            ClusterPosition { id: 0, note: Some(3) }, // Append at the end
+            ClusterPosition {
+                id: 1,
+                note: Some(1),
+            },
+            ClusterPosition {
+                id: 2,
+                note: Some(2),
+            },
+            ClusterPosition {
+                id: 0,
+                note: Some(3),
+            }, // Append at the end
         ];
         let preview = db.preview_citation_cluster(cites, PreviewPosition::MarkWithZero(positions), None);
         assert_cluster!(preview.ok(), Some("Book one, subsequent"));
@@ -221,9 +233,18 @@ mod preview {
         let mut db = mk_db();
         let cites = vec![Cite::basic("one"), Cite::basic("three")];
         let positions = &[
-            ClusterPosition { id: 0, note: Some(1) }, // Insert into the first note, at the start.
-            ClusterPosition { id: 1, note: Some(1) },
-            ClusterPosition { id: 2, note: Some(2) },
+            ClusterPosition {
+                id: 0,
+                note: Some(1),
+            }, // Insert into the first note, at the start.
+            ClusterPosition {
+                id: 1,
+                note: Some(1),
+            },
+            ClusterPosition {
+                id: 2,
+                note: Some(2),
+            },
         ];
         let preview = db.preview_citation_cluster(cites, PreviewPosition::MarkWithZero(positions), None);
         assert_cluster!(preview.ok(), Some("Book one; Book three"));
@@ -236,15 +257,20 @@ mod preview {
         let mut db = mk_db();
         let cites = vec![Cite::basic("three")];
         let positions = &[
-            ClusterPosition { id: 0, note: Some(1) }, // Replace cluster #1
-            ClusterPosition { id: 2, note: Some(2) },
+            ClusterPosition {
+                id: 0,
+                note: Some(1),
+            }, // Replace cluster #1
+            ClusterPosition {
+                id: 2,
+                note: Some(2),
+            },
         ];
         let preview = db.preview_citation_cluster(cites, PreviewPosition::MarkWithZero(positions), None);
         assert_cluster!(preview.ok(), Some("Book three"));
         assert_cluster!(db.get_cluster(1), Some("Book one"));
         assert_cluster!(db.get_cluster(2), Some("Book two"));
     }
-
 }
 
 mod terms {

--- a/crates/csl/src/locale.rs
+++ b/crates/csl/src/locale.rs
@@ -317,7 +317,10 @@ impl Locale {
             .map(|term_plurality| term_plurality.singular())
     }
 
-    pub fn et_al_term(&self, element: Option<&crate::NameEtAl>) -> Option<(String, Option<Formatting>)> {
+    pub fn et_al_term(
+        &self,
+        element: Option<&crate::NameEtAl>,
+    ) -> Option<(String, Option<Formatting>)> {
         let mut term = MiscTerm::EtAl;
         let mut default = "et al";
         let mut formatting = None;

--- a/crates/csl/src/style/mod.rs
+++ b/crates/csl/src/style/mod.rs
@@ -4,7 +4,7 @@
 //
 // Copyright © 2018 Corporation for Digital Scholarship
 
-use super::terms::{TermForm, TermFormExtended, TextTermSelector, Category};
+use super::terms::{Category, TermForm, TermFormExtended, TextTermSelector};
 use super::IsIndependent;
 use crate::error::*;
 use crate::locale::{Lang, Locale};

--- a/crates/csl/src/variables.rs
+++ b/crates/csl/src/variables.rs
@@ -90,9 +90,7 @@ impl IsIndependent for Variable {
         match self {
             // Variable::CitationLabel is not independent, it just implies a YearSuffix
             // which is, and that is handled in FreeCondWalker::text_variable()
-            Variable::LocatorExtra
-            | Variable::YearSuffix
-            | Variable::Hereinafter => true,
+            Variable::LocatorExtra | Variable::YearSuffix | Variable::Hereinafter => true,
             _ => false,
         }
     }

--- a/crates/csl/src/version.rs
+++ b/crates/csl/src/version.rs
@@ -201,7 +201,6 @@ declare_features!(
     (active, term_every_type, "1.0.1", None, None),
     (active, term_unpublished, "1.0.1", None, None),
     (active, term_legal_locators, "1.0.1", None, None),
-
     // Enables using editortranslator as a CSL-JSON and CSL variable directly, avoiding
     // the need for "editor translator"
     //

--- a/crates/db/src/cite.rs
+++ b/crates/db/src/cite.rs
@@ -92,11 +92,15 @@ impl CiteId {
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub enum CiteData {
     /// This represents an actual cite in an actual cluster in the document.
-    RealCite { cluster: ClusterId, index: u32, cite: Arc<Cite<Markup>> },
+    RealCite {
+        cluster: ClusterId,
+        index: u32,
+        cite: Arc<Cite<Markup>>,
+    },
     /// These are created as necessary when uncited items need to be rendered for disambiguation.
     /// The Arc<Cite> is the null object pattern, used merely to hold a reference id but keep the
     /// cite IR rendering identical for ghost and real cites.
-    BibliographyGhost { cite: Arc<Cite<Markup>>, },
+    BibliographyGhost { cite: Arc<Cite<Markup>> },
 }
 
 fn ghost_cite(_db: &dyn CiteDatabase, ref_id: Atom) -> Arc<Cite<Markup>> {

--- a/crates/db/src/xml.rs
+++ b/crates/db/src/xml.rs
@@ -318,10 +318,7 @@ pub struct PredefinedLocales(pub HashMap<Lang, String>);
 impl PredefinedLocales {
     pub fn bundled_en_us() -> Self {
         let mut m = HashMap::new();
-        m.insert(
-            Lang::en_us(),
-            EN_US.to_owned(),
-        );
+        m.insert(Lang::en_us(), EN_US.to_owned());
         PredefinedLocales(m)
     }
 }

--- a/crates/io/src/cite.rs
+++ b/crates/io/src/cite.rs
@@ -274,4 +274,3 @@ pub struct ClusterPosition {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub note: Option<u32>,
 }
-

--- a/crates/io/src/date.rs
+++ b/crates/io/src/date.rs
@@ -49,7 +49,9 @@ impl PartialOrd for DateOrRange {
             (DateOrRange::Single(a), DateOrRange::Single(b)) => Some(a.cmp(b)),
             (DateOrRange::Range(a1, a2), DateOrRange::Single(b)) => Some(a1.cmp(b).then(a2.cmp(b))),
             (DateOrRange::Single(a), DateOrRange::Range(b1, b2)) => Some(a.cmp(b1).then(a.cmp(b2))),
-            (DateOrRange::Range(a1, a2), DateOrRange::Range(b1, b2)) => Some(a1.cmp(b1).then(a2.cmp(b2))),
+            (DateOrRange::Range(a1, a2), DateOrRange::Range(b1, b2)) => {
+                Some(a1.cmp(b1).then(a2.cmp(b2)))
+            }
         }
     }
 }

--- a/crates/io/src/names.rs
+++ b/crates/io/src/names.rs
@@ -50,7 +50,10 @@ fn split_particles(mut orig_name_str: &str, is_given: bool) -> Option<(String, S
     let family_particles_re = regex!("^\\S+(?:\\-|\u{02bb}|\u{2019}|\\s|\')\\s*");
     debug!("split_particles: {:?}", orig_name_str);
     let (splitter, name_str) = if is_given {
-        (givenn_particles_re, Cow::Owned(orig_name_str.chars().rev().collect()))
+        (
+            givenn_particles_re,
+            Cow::Owned(orig_name_str.chars().rev().collect()),
+        )
     } else {
         (family_particles_re, Cow::Borrowed(orig_name_str))
     };
@@ -85,7 +88,7 @@ fn split_particles(mut orig_name_str: &str, is_given: bool) -> Option<(String, S
         if particles.len() > 1 {
             for i in 1..particles.len() {
                 if particles[i].chars().nth(0) == Some(' ') {
-                    particles[i-1].to_mut().push(' ');
+                    particles[i - 1].to_mut().push(' ');
                 }
             }
         }
@@ -102,7 +105,10 @@ fn split_particles(mut orig_name_str: &str, is_given: bool) -> Option<(String, S
         None
     } else {
         use itertools::Itertools;
-        Some((particles.iter().map(|cow| cow.as_ref()).join(""), replace_apostrophes(remain)))
+        Some((
+            particles.iter().map(|cow| cow.as_ref()).join(""),
+            replace_apostrophes(remain),
+        ))
     }
 }
 
@@ -140,9 +146,11 @@ fn trim_last(string: &mut String) {
     // graphemes unnecessary as particles basically end with one of a few select characters in the
     // regex below
     if let Some(last_char) = last_char {
-        if last_char == ' ' && string.chars().rev().nth(0).map_or(false, |second_last| {
-            second_last == '\'' || second_last == '\u{2019}'
-        }) {
+        if last_char == ' '
+            && string.chars().rev().nth(0).map_or(false, |second_last| {
+                second_last == '\'' || second_last == '\u{2019}'
+            })
+        {
             string.push(' ');
         }
     }
@@ -160,10 +168,16 @@ impl PersonName {
             comma_suffix,
         } = self;
         // Don't parse if these are supplied
-        if *static_particles || non_dropping_particle.is_some() || dropping_particle.is_some() || suffix.is_some() {
+        if *static_particles
+            || non_dropping_particle.is_some()
+            || dropping_particle.is_some()
+            || suffix.is_some()
+        {
             *family = family.as_ref().map(|x| replace_apostrophes(x));
             *given = given.as_ref().map(|x| replace_apostrophes(x));
-            *non_dropping_particle = non_dropping_particle.as_ref().map(|x| replace_apostrophes(x));
+            *non_dropping_particle = non_dropping_particle
+                .as_ref()
+                .map(|x| replace_apostrophes(x));
             *dropping_particle = dropping_particle.as_ref().map(|x| replace_apostrophes(x));
             return;
         }
@@ -205,12 +219,15 @@ fn parse_particles() {
         ..Default::default()
     };
     init.parse_particles();
-    assert_eq!(init, PersonName {
-        given: Some("Schnitzel".to_owned()),
-        non_dropping_particle: Some("von".to_owned()),
-        family: Some("Crumb".to_owned()),
-        ..Default::default()
-    });
+    assert_eq!(
+        init,
+        PersonName {
+            given: Some("Schnitzel".to_owned()),
+            non_dropping_particle: Some("von".to_owned()),
+            family: Some("Crumb".to_owned()),
+            ..Default::default()
+        }
+    );
 
     let mut init = PersonName {
         given: Some("Eric".to_owned()),
@@ -218,12 +235,15 @@ fn parse_particles() {
         ..Default::default()
     };
     init.parse_particles();
-    assert_eq!(init, PersonName {
-        given: Some("Eric".to_owned()),
-        non_dropping_particle: Some("van der".to_owned()),
-        family: Some("Vlist".to_owned()),
-        ..Default::default()
-    });
+    assert_eq!(
+        init,
+        PersonName {
+            given: Some("Eric".to_owned()),
+            non_dropping_particle: Some("van der".to_owned()),
+            family: Some("Vlist".to_owned()),
+            ..Default::default()
+        }
+    );
 
     let mut init = PersonName {
         given: Some("Eric".to_owned()),
@@ -231,12 +251,15 @@ fn parse_particles() {
         ..Default::default()
     };
     init.parse_particles();
-    assert_eq!(init, PersonName {
-        given: Some("Eric".to_owned()),
-        non_dropping_particle: Some("del".to_owned()),
-        family: Some("Familyname".to_owned()),
-        ..Default::default()
-    });
+    assert_eq!(
+        init,
+        PersonName {
+            given: Some("Eric".to_owned()),
+            non_dropping_particle: Some("del".to_owned()),
+            family: Some("Familyname".to_owned()),
+            ..Default::default()
+        }
+    );
 
     let mut init = PersonName {
         given: Some("Givenname d'".to_owned()),
@@ -244,12 +267,15 @@ fn parse_particles() {
         ..Default::default()
     };
     init.parse_particles();
-    assert_eq!(init, PersonName {
-        given: Some("Givenname".to_owned()),
-        dropping_particle: Some("d\u{2019}".to_owned()),
-        family: Some("Familyname".to_owned()),
-        ..Default::default()
-    });
+    assert_eq!(
+        init,
+        PersonName {
+            given: Some("Givenname".to_owned()),
+            dropping_particle: Some("d\u{2019}".to_owned()),
+            family: Some("Familyname".to_owned()),
+            ..Default::default()
+        }
+    );
 
     let mut init = PersonName {
         family: Some("Aubignac".to_owned()),
@@ -257,12 +283,15 @@ fn parse_particles() {
         ..Default::default()
     };
     init.parse_particles();
-    assert_eq!(init, PersonName {
-        given: Some("François Hédelin".to_owned()),
-        dropping_particle: Some("d\u{2019}".to_owned()),
-        family: Some("Aubignac".to_owned()),
-        ..Default::default()
-    });
+    assert_eq!(
+        init,
+        PersonName {
+            given: Some("François Hédelin".to_owned()),
+            dropping_particle: Some("d\u{2019}".to_owned()),
+            family: Some("Aubignac".to_owned()),
+            ..Default::default()
+        }
+    );
 
     let mut init = PersonName {
         family: Some("d’Aubignac".to_owned()),
@@ -270,24 +299,25 @@ fn parse_particles() {
         ..Default::default()
     };
     init.parse_particles();
-    assert_eq!(init, PersonName {
-        given: Some("François Hédelin".to_owned()),
-        non_dropping_particle: Some("d\u{2019}".to_owned()),
-        family: Some("Aubignac".to_owned()),
-        ..Default::default()
-    });
-
+    assert_eq!(
+        init,
+        PersonName {
+            given: Some("François Hédelin".to_owned()),
+            non_dropping_particle: Some("d\u{2019}".to_owned()),
+            family: Some("Aubignac".to_owned()),
+            ..Default::default()
+        }
+    );
 }
 
 /// https://users.rust-lang.org/t/trim-string-in-place/15809/8
 pub trait TrimInPlace {
-    fn trim_in_place (self: &'_ mut Self);
-    fn trim_start_in_place (self: &'_ mut Self);
-    fn trim_end_in_place (self: &'_ mut Self);
+    fn trim_in_place(self: &'_ mut Self);
+    fn trim_start_in_place(self: &'_ mut Self);
+    fn trim_end_in_place(self: &'_ mut Self);
 }
 impl TrimInPlace for String {
-    fn trim_in_place (self: &'_ mut Self)
-    {
+    fn trim_in_place(self: &'_ mut Self) {
         let (start, len): (*const u8, usize) = {
             let self_trimmed: &str = self.trim();
             (self_trimmed.as_ptr(), self_trimmed.len())
@@ -301,8 +331,7 @@ impl TrimInPlace for String {
         }
         self.truncate(len); // no String::set_len() in std ...
     }
-    fn trim_start_in_place (self: &'_ mut Self)
-    {
+    fn trim_start_in_place(self: &'_ mut Self) {
         let (start, len): (*const u8, usize) = {
             let self_trimmed: &str = self.trim_start();
             (self_trimmed.as_ptr(), self_trimmed.len())
@@ -316,8 +345,7 @@ impl TrimInPlace for String {
         }
         self.truncate(len); // no String::set_len() in std ...
     }
-    fn trim_end_in_place (self: &'_ mut Self)
-    {
+    fn trim_end_in_place(self: &'_ mut Self) {
         self.truncate(self.trim_end().len());
     }
 }

--- a/crates/io/src/output/markup.rs
+++ b/crates/io/src/output/markup.rs
@@ -10,7 +10,8 @@ use super::{FormatCmd, LocalizedQuotes, OutputFormat};
 use crate::utils::JoinMany;
 use crate::IngestOptions;
 use csl::{
-    DisplayMode, FontStyle, FontVariant, FontWeight, Formatting, TextDecoration, VerticalAlignment, TextCase,
+    DisplayMode, FontStyle, FontVariant, FontWeight, Formatting, TextCase, TextDecoration,
+    VerticalAlignment,
 };
 
 mod rtf;

--- a/crates/io/src/output/markup/flip_flop.rs
+++ b/crates/io/src/output/markup/flip_flop.rs
@@ -32,12 +32,10 @@ impl FlipFlopState {
     }
     pub fn flip_flop_inlines(&self, inlines: &[InlineElement]) -> Vec<InlineElement> {
         let mut new = Vec::with_capacity(inlines.len());
-        inlines
-            .iter()
-            .for_each(|inl| match flip_flop(inl, self) {
-                Ok(x) => new.push(x),
-                Err(vec) => new.extend(vec.into_iter()),
-            });
+        inlines.iter().for_each(|inl| match flip_flop(inl, self) {
+            Ok(x) => new.push(x),
+            Err(vec) => new.extend(vec.into_iter()),
+        });
         new
     }
     /// Retval is whether any change resulted
@@ -51,12 +49,18 @@ impl FlipFlopState {
             FormatCmd::FontWeightNormal => self.font_weight = FontWeight::Normal,
             FormatCmd::FontWeightLight => self.font_weight = FontWeight::Light,
             FormatCmd::FontVariantSmallCaps => self.font_variant = FontVariant::SmallCaps,
-            FormatCmd::FontVariantNormal => self.font_variant  = FontVariant::Normal,
+            FormatCmd::FontVariantNormal => self.font_variant = FontVariant::Normal,
             FormatCmd::TextDecorationUnderline => self.text_decoration = TextDecoration::Underline,
             FormatCmd::TextDecorationNone => self.text_decoration = TextDecoration::None,
-            FormatCmd::VerticalAlignmentSuperscript => self.vertical_alignment = VerticalAlignment::Superscript,
-            FormatCmd::VerticalAlignmentSubscript => self.vertical_alignment = VerticalAlignment::Subscript,
-            FormatCmd::VerticalAlignmentBaseline => self.vertical_alignment = VerticalAlignment::Baseline,
+            FormatCmd::VerticalAlignmentSuperscript => {
+                self.vertical_alignment = VerticalAlignment::Superscript
+            }
+            FormatCmd::VerticalAlignmentSubscript => {
+                self.vertical_alignment = VerticalAlignment::Subscript
+            }
+            FormatCmd::VerticalAlignmentBaseline => {
+                self.vertical_alignment = VerticalAlignment::Baseline
+            }
             _ => return false,
             // FormatCmd::DisplayBlock,
             // FormatCmd::DisplayIndent,
@@ -67,7 +71,10 @@ impl FlipFlopState {
     }
 }
 
-fn flip_flop(inline: &InlineElement, state: &FlipFlopState) -> Result<InlineElement, Vec<InlineElement>> {
+fn flip_flop(
+    inline: &InlineElement,
+    state: &FlipFlopState,
+) -> Result<InlineElement, Vec<InlineElement>> {
     match *inline {
         InlineElement::Micro(ref nodes) => {
             let nodes = flip_flop_nodes(nodes, state);
@@ -168,7 +175,9 @@ fn flip_flop_node(node: &MicroNode, state: &FlipFlopState) -> Result<MicroNode, 
         MicroNode::Formatted(ref nodes, cmd) => {
             let mut flop = state.clone();
             match cmd {
-                FormatCmd::FontStyleItalic | FormatCmd::FontStyleNormal | FormatCmd::FontStyleOblique => {
+                FormatCmd::FontStyleItalic
+                | FormatCmd::FontStyleNormal
+                | FormatCmd::FontStyleOblique => {
                     let is_italic = |x| x != FontStyle::Normal;
                     let outer = state.font_style;
                     flop.push_cmd(*cmd);
@@ -185,7 +194,9 @@ fn flip_flop_node(node: &MicroNode, state: &FlipFlopState) -> Result<MicroNode, 
                         Ok(MicroNode::Formatted(nodes, *cmd))
                     }
                 }
-                FormatCmd::FontWeightBold | FormatCmd::FontWeightLight | FormatCmd::FontWeightNormal => {
+                FormatCmd::FontWeightBold
+                | FormatCmd::FontWeightLight
+                | FormatCmd::FontWeightNormal => {
                     let outer = state.font_weight;
                     flop.push_cmd(*cmd);
                     let inner = flop.font_weight;
@@ -258,6 +269,6 @@ fn flip_flop_node(node: &MicroNode, state: &FlipFlopState) -> Result<MicroNode, 
                 }
                 Err(out)
             }
-        },
+        }
     }
 }

--- a/crates/io/src/output/mod.rs
+++ b/crates/io/src/output/mod.rs
@@ -138,7 +138,11 @@ pub trait OutputFormat: Send + Sync + Clone + Default + PartialEq + std::fmt::De
 
     fn is_empty(&self, a: &Self::Build) -> bool;
     fn output(&self, intermediate: Self::Build, punctuation_in_quote: bool) -> Self::Output {
-        self.output_in_context(intermediate, Formatting::default(), Some(punctuation_in_quote))
+        self.output_in_context(
+            intermediate,
+            Formatting::default(),
+            Some(punctuation_in_quote),
+        )
     }
 
     fn output_in_context(

--- a/crates/io/src/output/plain.rs
+++ b/crates/io/src/output/plain.rs
@@ -95,7 +95,12 @@ impl OutputFormat for PlainText {
     }
 
     #[inline]
-    fn output_in_context(&self, intermediate: Self::Build, _formatting: Formatting, _punctuation_in_quote: Option<bool>) -> Self::Output {
+    fn output_in_context(
+        &self,
+        intermediate: Self::Build,
+        _formatting: Formatting,
+        _punctuation_in_quote: Option<bool>,
+    ) -> Self::Output {
         intermediate
     }
 

--- a/crates/io/src/reference.rs
+++ b/crates/io/src/reference.rs
@@ -13,8 +13,8 @@ use fnv::FnvHashMap;
 use super::date::DateOrRange;
 use super::names::Name;
 use super::numeric::NumericValue;
-use csl::{Atom, CslType, DateVariable, Lang, NameVariable, NumberVariable, Variable};
 use crate::NumberLike;
+use csl::{Atom, CslType, DateVariable, Lang, NameVariable, NumberVariable, Variable};
 
 // We're saving copies and allocations by not using String here.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/proc/Cargo.toml
+++ b/crates/proc/Cargo.toml
@@ -13,7 +13,6 @@ serde_derive = "1.0.100"
 fnv = "1.0.6"
 ucd-trie = "0.1.2"
 petgraph = "0.4.13"
-generational-arena = "0.2.2"
 cfg-if = "0.1.9"
 salsa = "0.15.2"
 citeproc-db = { path = "../db" }
@@ -28,6 +27,7 @@ parking_lot = "0.9.0"
 nom = { version = "5.0.1", default-features = false, features = ["std"] }
 unicase = "2.6.0"
 unic-segment = "0.9.0"
+indextree = "4.3.1"
 
 [dev-dependencies]
 lazy_static = "1.4.0"

--- a/crates/proc/src/choose.rs
+++ b/crates/proc/src/choose.rs
@@ -24,23 +24,24 @@ where
         ctx: &CiteContext<'c, O, I>,
         arena: &mut IrArena<O>,
     ) -> NodeId {
-        let maybe_leave_unresolved = |unresolved: bool, sub_node: NodeId, arena: &mut IrArena<O>| {
-            if unresolved {
-                let gv = arena.get(sub_node).unwrap().get().1;
-                let cond = arena.new_node((
-                    IR::ConditionalDisamb(ConditionalDisambIR {
-                        choose: self.clone(),
-                        done: false,
-                        group_vars: gv,
-                    }),
-                    gv,
-                ));
-                cond.append(sub_node, arena);
-                cond
-            } else {
-                sub_node
-            }
-        };
+        let maybe_leave_unresolved =
+            |unresolved: bool, sub_node: NodeId, arena: &mut IrArena<O>| {
+                if unresolved {
+                    let gv = arena.get(sub_node).unwrap().get().1;
+                    let cond = arena.new_node((
+                        IR::ConditionalDisamb(ConditionalDisambIR {
+                            choose: self.clone(),
+                            done: false,
+                            group_vars: gv,
+                        }),
+                        gv,
+                    ));
+                    cond.append(sub_node, arena);
+                    cond
+                } else {
+                    sub_node
+                }
+            };
         // XXX: should you treat conditional evaluations as a "variable test"?
         let Choose(ref head, ref rest, ref last) = **self;
         let mut disamb = false;

--- a/crates/proc/src/choose.rs
+++ b/crates/proc/src/choose.rs
@@ -25,20 +25,23 @@ where
         db: &dyn IrDatabase,
         state: &mut IrState,
         ctx: &CiteContext<'c, O, I>,
-    ) -> IrSum<O> {
-        let make_mutex = |d: bool, content: IR<O>, gv: GroupVars| {
-            if d {
-                (
-                    IR::ConditionalDisamb(Arc::new(Mutex::new(ConditionalDisambIR {
+        arena: &mut IrArena<O>,
+    ) -> NodeId {
+        let make_mutex = |unresolved: bool, content: IR<O>, gv: GroupVars| {
+            let sub_node = arena.new_node((content, gv));
+            if unresolved {
+                let cond = arena.new_node((
+                    IR::ConditionalDisamb(ConditionalDisambIR {
                         choose: self.clone(),
                         done: false,
-                        ir: Box::new(content),
                         group_vars: gv,
-                    }))),
+                    }),
                     gv,
-                )
+                ));
+                cond.append(sub_node);
+                cond
             } else {
-                (content, gv)
+                sub_node
             }
         };
         // XXX: should you treat conditional evaluations as a "variable test"?

--- a/crates/proc/src/choose.rs
+++ b/crates/proc/src/choose.rs
@@ -8,10 +8,8 @@ use crate::prelude::*;
 
 use crate::ir::ConditionalDisambIR;
 use citeproc_io::DateOrRange;
-use csl::{
-    Choose, Cond, CondSet, Conditions, CslType, Element, Else, IfThen, Match, Position,
-};
 use csl::{AnyVariable, DateVariable};
+use csl::{Choose, Cond, CondSet, Conditions, CslType, Element, Else, IfThen, Match, Position};
 
 use std::sync::{Arc, Mutex};
 

--- a/crates/proc/src/choose.rs
+++ b/crates/proc/src/choose.rs
@@ -32,9 +32,8 @@ where
                         IR::ConditionalDisamb(ConditionalDisambIR {
                             choose: self.clone(),
                             done: false,
-                            group_vars: gv,
                         }),
-                        gv,
+                        gv, // TODO: should this be unresolved?
                     ));
                     cond.append(sub_node, arena);
                     cond

--- a/crates/proc/src/citation_label.rs
+++ b/crates/proc/src/citation_label.rs
@@ -82,6 +82,7 @@ impl Default for Trigraph {
 
 #[test]
 fn test_write_label() {
+    use citeproc_io::{Date, DateOrRange};
     let trigraph = Trigraph::default();
     use csl::CslType;
     let mut refr = Reference::empty("ref_id".into(), CslType::Book);

--- a/crates/proc/src/citation_label.rs
+++ b/crates/proc/src/citation_label.rs
@@ -1,4 +1,4 @@
-use citeproc_io::{Date, DateOrRange, Name, PersonName, Reference};
+use citeproc_io::{Name, PersonName, Reference};
 use csl::{DateVariable, NameVariable};
 
 #[derive(Debug, PartialEq, Eq)]
@@ -154,9 +154,9 @@ mod parser {
     use super::*;
     use nom::{
         branch::alt,
-        bytes::complete::{take_while, take_while1, take_while_m_n},
+        bytes::complete::{take_while, take_while1},
         character::complete::char,
-        combinator::{map, opt, recognize},
+        combinator::recognize,
         multi::{many1, separated_nonempty_list},
         IResult,
     };

--- a/crates/proc/src/citation_label.rs
+++ b/crates/proc/src/citation_label.rs
@@ -1,5 +1,5 @@
-use citeproc_io::{Reference, Name, PersonName, DateOrRange, Date};
-use csl::{NameVariable, DateVariable};
+use citeproc_io::{Date, DateOrRange, Name, PersonName, Reference};
+use csl::{DateVariable, NameVariable};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Trigraph(Vec<Vec<ConfigCell>>);
@@ -23,8 +23,8 @@ impl Trigraph {
         if self.0.len() == 0 {
             return string;
         }
-        use unic_segment::Graphemes;
         use std::fmt::Write;
+        use unic_segment::Graphemes;
         if let Some(authors) = authors {
             let count = authors.len();
             let ix = std::cmp::min(count, self.0.len()) - 1;
@@ -48,9 +48,11 @@ impl Trigraph {
                         _ => {
                             prog += 1;
                             continue;
-                        },
+                        }
                     };
-                    let len = Graphemes::new(name_to_write).take(author_printer as usize).fold(0, |acc, x| acc + x.len());
+                    let len = Graphemes::new(name_to_write)
+                        .take(author_printer as usize)
+                        .fold(0, |acc, x| acc + x.len());
                     write!(string, "{}", &name_to_write[..len]).unwrap();
                     prog += 1;
                 }
@@ -73,7 +75,8 @@ impl Trigraph {
 
 impl Default for Trigraph {
     fn default() -> Self {
-        Trigraph::parse("Aaaa00:AaAa00:AaAA00:AAAA00").expect("Trigraph ought to parse the default!")
+        Trigraph::parse("Aaaa00:AaAa00:AaAA00:AAAA00")
+            .expect("Trigraph ought to parse the default!")
     }
 }
 
@@ -82,24 +85,31 @@ fn test_write_label() {
     let trigraph = Trigraph::default();
     use csl::CslType;
     let mut refr = Reference::empty("ref_id".into(), CslType::Book);
-    refr.name.insert(NameVariable::Author, vec![
-        Name::Person(PersonName {
+    refr.name.insert(
+        NameVariable::Author,
+        vec![Name::Person(PersonName {
             family: Some("Jobs".to_owned()),
             ..Default::default()
-        })
-    ]);
-    refr.date.insert(DateVariable::Issued, DateOrRange::Single(Date::new(1995, 0, 0)));
+        })],
+    );
+    refr.date.insert(
+        DateVariable::Issued,
+        DateOrRange::Single(Date::new(1995, 0, 0)),
+    );
     assert_eq!(trigraph.make_label(&refr), "Jobs95".to_owned());
-    refr.name.insert(NameVariable::Author, vec![
-        Name::Person(PersonName {
-            family: Some("Boris".to_owned()),
-            ..Default::default()
-        }),
-        Name::Person(PersonName {
-            family: Some("Johnson".to_owned()),
-            ..Default::default()
-        })
-    ]);
+    refr.name.insert(
+        NameVariable::Author,
+        vec![
+            Name::Person(PersonName {
+                family: Some("Boris".to_owned()),
+                ..Default::default()
+            }),
+            Name::Person(PersonName {
+                family: Some("Johnson".to_owned()),
+                ..Default::default()
+            }),
+        ],
+    );
     assert_eq!(trigraph.make_label(&refr), "BoJo95".to_owned());
 }
 
@@ -174,7 +184,10 @@ mod parser {
 
     #[test]
     fn test_author() {
-        assert_eq!(author("Aaaa"), Ok(("", ConfigCell::Author { first_n_letters: 4 })))
+        assert_eq!(
+            author("Aaaa"),
+            Ok(("", ConfigCell::Author { first_n_letters: 4 }))
+        )
     }
 
     pub(super) fn colon_separated(inp: &str) -> IResult<&str, Vec<Vec<ConfigCell>>> {

--- a/crates/proc/src/cite_context.rs
+++ b/crates/proc/src/cite_context.rs
@@ -14,8 +14,8 @@ use csl::Features;
 use csl::Locale;
 use csl::*;
 use csl::{CslType, Delimiter, Name as NameEl, Position, SortKey, Style, VariableForm};
-use std::sync::Arc;
 use std::borrow::Cow;
+use std::sync::Arc;
 
 #[derive(Clone)]
 pub struct CiteContext<
@@ -42,7 +42,6 @@ pub struct CiteContext<
 
     pub in_bibliography: bool,
     pub sort_key: Option<SortKey>,
-
 
     /// It isn't easy to sort by year-suffix. Year-suffix disambiguation requires a representation
     /// of the style's output (Called ir_gen2 in citeproc-rs). This requires knowing a cite's
@@ -85,7 +84,7 @@ impl<'c, O: OutputFormat, I: OutputFormat> CiteContext<'c, O, I> {
 
 impl<'c, O: OutputFormat, I: OutputFormat> CiteContext<'c, O, I> {
     pub fn get_ordinary(&self, var: Variable, form: VariableForm) -> Option<Cow<'_, str>> {
-        (match (var, form) {
+        match (var, form) {
             (Variable::TitleShort, _) | (Variable::Title, VariableForm::Short) => self
                 .reference
                 .ordinary
@@ -106,10 +105,13 @@ impl<'c, O: OutputFormat, I: OutputFormat> CiteContext<'c, O, I> {
                 let tri = crate::citation_label::Trigraph::default();
                 Some(Cow::Owned(tri.make_label(self.reference)))
             }
-            _ => self.reference.ordinary.get(&var)
+            _ => self
+                .reference
+                .ordinary
+                .get(&var)
                 .map(|s| s.as_str())
                 .map(Cow::Borrowed),
-        })
+        }
     }
 
     pub fn has_variable(&self, var: AnyVariable) -> bool {

--- a/crates/proc/src/db.rs
+++ b/crates/proc/src/db.rs
@@ -1499,13 +1499,15 @@ fn get_bibliography_map(db: &dyn IrDatabase) -> Arc<FnvHashMap<Atom, Arc<MarkupO
                     .map(|x| (x.as_ref(), bib.subsequent_author_substitute_rule))
             });
             if let (Some(prev_name_block), Some(current_name_block), Some((sas, sas_rule))) = (
-                prev.as_ref().and_then(|(root, gen)| gen.arena.get(*root)),
+                prev.as_ref().and_then(|(first_block, gen)| gen.arena.get(*first_block)),
                 current,
                 sas,
             ) {
                 let mutated = Arc::make_mut(&mut gen0);
                 let did = crate::transforms::subsequent_author_substitute(
                     &fmt,
+                    // In order to unwrap this here, you must only replace the NameIR node's
+                    // children, not the IR.
                     prev_name_block.get().0.unwrap_name_ir(),
                     current_name_block,
                     &mut mutated.arena,

--- a/crates/proc/src/db.rs
+++ b/crates/proc/src/db.rs
@@ -816,6 +816,7 @@ fn disambiguate_add_year_suffix(
         };
         let gv = sum.1;
         let node = arena.new_node(sum);
+        yid.append(node, arena);
         let (ys, ys_gv) = get_ys_mut(yid, arena);
         *ys_gv = gv;
         ys.suffix_num = Some(suffix);
@@ -835,6 +836,7 @@ fn disambiguate_add_year_suffix(
         };
         let gv = sum.1;
         let node = arena.new_node(sum);
+        yid.append(node, arena);
         let (ys, ys_gv) = get_ys_mut(yid, arena);
         *ys_gv = gv;
         ys.suffix_num = Some(suffix);

--- a/crates/proc/src/db.rs
+++ b/crates/proc/src/db.rs
@@ -909,7 +909,6 @@ fn ir_gen0(db: &dyn IrDatabase, id: CiteId) -> Arc<IrGen> {
     let _fmt = db.get_formatter();
     let matching = refs_accepting_cite(db, root, &arena, &ctx);
     let irgen = IrGen::new(root, arena, matching, state);
-    debug!("{:?}", irgen);
     Arc::new(irgen)
 }
 
@@ -1096,7 +1095,7 @@ pub fn built_cluster_before_output(
             let cite = id.lookup(db);
             let (_keys, citation_numbers_by_id) = &*sorted_refs_arc;
             let cnum = citation_numbers_by_id.get(&cite.ref_id).cloned();
-            Unnamed3::new(cite, cnum, gen4.clone())
+            Unnamed3::new(cite, cnum, gen4)
         })
         .collect();
 
@@ -1499,7 +1498,8 @@ fn get_bibliography_map(db: &dyn IrDatabase) -> Arc<FnvHashMap<Atom, Arc<MarkupO
                     .map(|x| (x.as_ref(), bib.subsequent_author_substitute_rule))
             });
             if let (Some(prev_name_block), Some(current_name_block), Some((sas, sas_rule))) = (
-                prev.as_ref().and_then(|(first_block, gen)| gen.arena.get(*first_block)),
+                prev.as_ref()
+                    .and_then(|(first_block, gen)| gen.arena.get(*first_block)),
                 current,
                 sas,
             ) {

--- a/crates/proc/src/db.rs
+++ b/crates/proc/src/db.rs
@@ -766,8 +766,8 @@ fn disambiguate_add_year_suffix(
     let mut added_suffix = false;
     for yid in hooks {
         let ys = get_ys_mut(yid, arena);
-        let sum: IrSum<Markup> = match &ysh.hook {
-            YearSuffixHook::Explicit(_) => ysh.hook.render(ctx, suffix),
+        let sum: IrSum<Markup> = match &ys.hook {
+            YearSuffixHook::Explicit(_) => ys.hook.render(ctx, suffix),
             _ => continue,
         };
         let gv = sum.1;
@@ -785,8 +785,8 @@ fn disambiguate_add_year_suffix(
     // Then attempt to do it for the ones that are embedded in date output
     for yid in hooks {
         let ys = get_ys_mut(yid, arena);
-        let sum: IrSum<Markup> = match &ysh.hook {
-            YearSuffixHook::Plain => ysh.hook.render(ctx, suffix),
+        let sum: IrSum<Markup> = match &ys.hook {
+            YearSuffixHook::Plain => ys.hook.render(ctx, suffix),
             _ => continue,
         };
         let gv = sum.1;
@@ -1458,7 +1458,7 @@ fn get_bibliography_map(db: &dyn IrDatabase) -> Arc<FnvHashMap<Atom, Arc<MarkupO
                 let mutated = Arc::make_mut(&mut gen0);
                 let did = crate::transforms::subsequent_author_substitute(
                     &fmt,
-                    prev_name_block,
+                    prev_name_block.get().0.unwrap_name_ir(),
                     current_name_block,
                     &mut mutated.arena,
                     sas,

--- a/crates/proc/src/db.rs
+++ b/crates/proc/src/db.rs
@@ -1261,11 +1261,8 @@ pub fn built_cluster_before_output(
     let mut ix = 0;
     while ix < irs.len() {
         let Unnamed3 {
-            cite,
-            gen4,
             vanished,
             collapsed_ranges,
-            collapsed_year_suffixes,
             is_first,
             ..
         } = &irs[ix];

--- a/crates/proc/src/db.rs
+++ b/crates/proc/src/db.rs
@@ -816,7 +816,7 @@ fn disambiguate_add_year_suffix(
         };
         let gv = sum.1;
         let node = arena.new_node(sum);
-        yid.append(node, arena);
+        replace_single_child(yid, node, arena);
         let (ys, ys_gv) = get_ys_mut(yid, arena);
         *ys_gv = gv;
         ys.suffix_num = Some(suffix);

--- a/crates/proc/src/db.rs
+++ b/crates/proc/src/db.rs
@@ -516,7 +516,7 @@ fn list_all_cond_disambs(root: NodeId, arena: &IrArena<Markup>) -> Vec<NodeId> {
             Some(x) => x.get(),
             None => return,
         };
-        match me.0 {
+        match &me.0 {
             IR::NameCounter(_) | IR::YearSuffix(..) | IR::Rendered(_) | IR::Name(_) => {}
             IR::ConditionalDisamb(c) => {
                 vec.push(node);
@@ -597,7 +597,11 @@ fn disambiguate_add_names(
         nir.achieved_count(best);
 
         let is_sort_key = ctx.sort_key.is_some();
-        let label_after_name = nir.names_inheritance.label.map_or(false, |x| x.after_name);
+        let label_after_name = nir
+            .names_inheritance
+            .label
+            .as_ref()
+            .map_or(false, |x| x.after_name);
         // Probably use an Atom for this buddy
         let built_label = nir.built_label.clone();
 
@@ -754,7 +758,7 @@ fn disambiguate_add_year_suffix(
     // First see if we can do it with an explicit one
     let hooks = IR::list_year_suffix_hooks(root, arena);
     let mut added_suffix = false;
-    for yid in hooks {
+    for &yid in &hooks {
         let (ys, _) = get_ys_mut(yid, arena);
         let sum: IrSum<Markup> = match &ys.hook {
             YearSuffixHook::Explicit(_) => ys.hook.render(ctx, suffix),
@@ -765,6 +769,7 @@ fn disambiguate_add_year_suffix(
         let (ys, ys_gv) = get_ys_mut(yid, arena);
         *ys_gv = gv;
         ys.suffix_num = Some(suffix);
+        added_suffix = true;
         break;
     }
     if added_suffix {

--- a/crates/proc/src/disamb/implementation.rs
+++ b/crates/proc/src/disamb/implementation.rs
@@ -79,9 +79,7 @@ impl Disambiguation<Markup> for Element {
             Element::Choose(c) => c.ref_ir(db, ctx, state, stack),
             Element::Date(dt) => {
                 let var = dt.variable();
-                state.maybe_suppress_date(var, |state| {
-                    dt.ref_ir(db, ctx, state, stack)
-                })
+                state.maybe_suppress_date(var, |state| dt.ref_ir(db, ctx, state, stack))
             }
             Element::Number(number) => {
                 let var = number.variable;
@@ -94,9 +92,7 @@ impl Disambiguation<Markup> for Element {
                             let e = ctx.locator_type.map(|_| db.edge(EdgeData::Locator));
                             return (RefIR::Edge(e), GroupVars::Important);
                         }
-                        v => ctx
-                            .get_number(v)
-                            .map(|val| renderer.number(number, &val)),
+                        v => ctx.get_number(v).map(|val| renderer.number(number, &val)),
                     }
                 };
                 let content = content
@@ -141,8 +137,13 @@ impl Disambiguation<Markup> for Element {
                             None
                         } else {
                             state.maybe_suppress_ordinary(v);
-                            ctx.get_ordinary(v, form)
-                                .map(|val| renderer.text_variable(&crate::helpers::plain_text_element(v), var, &val))
+                            ctx.get_ordinary(v, form).map(|val| {
+                                renderer.text_variable(
+                                    &crate::helpers::plain_text_element(v),
+                                    var,
+                                    &val,
+                                )
+                            })
                         };
                         return vario
                             .map(|x| fmt.output_in_context(x, stack, None))
@@ -150,7 +151,8 @@ impl Disambiguation<Markup> for Element {
                             .map(|label| db.edge(label))
                             .map(|edge| {
                                 let label = RefIR::Edge(Some(edge));
-                                let suffix_edge = RefIR::Edge(Some(db.edge(EdgeData::YearSuffixPlain)));
+                                let suffix_edge =
+                                    RefIR::Edge(Some(db.edge(EdgeData::YearSuffixPlain)));
                                 let mut contents = Vec::new();
                                 contents.push(label);
                                 if ctx.year_suffix {

--- a/crates/proc/src/disamb/mod.rs
+++ b/crates/proc/src/disamb/mod.rs
@@ -390,9 +390,11 @@ pub fn add_to_graph(
             let affixes = affixes.as_ref();
             let mkedge = |s: &str| {
                 RefIR::Edge(if !s.is_empty() {
-                    Some(db.edge(EdgeData::Output(
-                        fmt.output_in_context(fmt.plain(s), Default::default(), None),
-                    )))
+                    Some(db.edge(EdgeData::Output(fmt.output_in_context(
+                        fmt.plain(s),
+                        Default::default(),
+                        None,
+                    ))))
                 } else {
                     None
                 })

--- a/crates/proc/src/disamb/mod.rs
+++ b/crates/proc/src/disamb/mod.rs
@@ -110,6 +110,9 @@ impl<'a> StyleWalker for FreeCondWalker<'a> {
     type Output = FreeCondSets;
     type Checker = crate::choose::UselessCondChecker;
 
+    fn default(&self) -> Self::Output {
+        FreeCondSets::default()
+    }
     /// For joining 2+ side-by-side FreeCondSets. This is the `sequence` for get_free_conds.
     fn fold(&mut self, elements: &[Element], _fold_type: WalkerFoldType) -> Self::Output {
         // TODO: keep track of which empty variables caused GroupVars to not render, if

--- a/crates/proc/src/disamb/mod.rs
+++ b/crates/proc/src/disamb/mod.rs
@@ -110,7 +110,7 @@ impl<'a> StyleWalker for FreeCondWalker<'a> {
     type Output = FreeCondSets;
     type Checker = crate::choose::UselessCondChecker;
 
-    fn default(&self) -> Self::Output {
+    fn default(&mut self) -> Self::Output {
         FreeCondSets::default()
     }
     /// For joining 2+ side-by-side FreeCondSets. This is the `sequence` for get_free_conds.

--- a/crates/proc/src/disamb/ref_context.rs
+++ b/crates/proc/src/disamb/ref_context.rs
@@ -3,8 +3,8 @@ use crate::prelude::*;
 use citeproc_io::output::markup::Markup;
 use citeproc_io::{DateOrRange, NumericValue, Reference};
 use csl::{Name as NameEl, *};
-use std::sync::Arc;
 use std::borrow::Cow;
+use std::sync::Arc;
 
 use crate::disamb::FreeCond;
 
@@ -110,7 +110,7 @@ where
     }
 
     pub fn get_ordinary(&self, var: Variable, form: VariableForm) -> Option<Cow<'_, str>> {
-        (match (var, form) {
+        match (var, form) {
             (Variable::TitleShort, _) | (Variable::Title, VariableForm::Short) => self
                 .reference
                 .ordinary
@@ -131,10 +131,13 @@ where
                 let tri = crate::citation_label::Trigraph::default();
                 Some(Cow::Owned(tri.make_label(self.reference)))
             }
-            _ => self.reference.ordinary.get(&var)
+            _ => self
+                .reference
+                .ordinary
+                .get(&var)
                 .map(|s| s.as_str())
                 .map(Cow::Borrowed),
-        })
+        }
     }
 
     pub fn get_number(&self, var: NumberVariable) -> Option<NumericValue<'_>> {
@@ -187,9 +190,7 @@ where
     }
     fn is_numeric(&self, var: AnyVariable) -> bool {
         match &var {
-            AnyVariable::Number(num) => self
-                .get_number(*num)
-                .map_or(false, |r| r.is_numeric()),
+            AnyVariable::Number(num) => self.get_number(*num).map_or(false, |r| r.is_numeric()),
             _ => false,
             // TODO: not very useful; implement for non-number variables (see CiteContext)
         }
@@ -239,6 +240,9 @@ use csl::Choose;
 impl<'a, O: OutputFormat> StyleWalker for DisambCounter<'a, O> {
     type Output = u32;
     type Checker = RefContext<'a, O>;
+    fn default(&self) -> Self::Output {
+        0
+    }
     fn fold(&mut self, elements: &[Element], _fold_type: WalkerFoldType) -> Self::Output {
         elements.iter().fold(0, |_acc, el| self.element(el))
     }

--- a/crates/proc/src/disamb/ref_context.rs
+++ b/crates/proc/src/disamb/ref_context.rs
@@ -240,7 +240,7 @@ use csl::Choose;
 impl<'a, O: OutputFormat> StyleWalker for DisambCounter<'a, O> {
     type Output = u32;
     type Checker = RefContext<'a, O>;
-    fn default(&self) -> Self::Output {
+    fn default(&mut self) -> Self::Output {
         0
     }
     fn fold(&mut self, elements: &[Element], _fold_type: WalkerFoldType) -> Self::Output {

--- a/crates/proc/src/disamb/test.rs
+++ b/crates/proc/src/disamb/test.rs
@@ -162,9 +162,8 @@ fn test() {
     let get_stream = |ind: usize| {
         let id = cite_ids[ind];
         let gen0 = db.ir_gen0(id);
-        let ir = &gen0.ir;
         let fmt = db.get_formatter();
-        ir.to_edge_stream(&fmt)
+        IR::to_edge_stream(gen0.root, &gen0.arena, &db.get_formatter())
     };
 
     let cite_edges = get_stream(0);

--- a/crates/proc/src/element.rs
+++ b/crates/proc/src/element.rs
@@ -277,7 +277,7 @@ impl<'a, O: OutputFormat, I: OutputFormat> StyleWalker for ProcWalker<'a, O, I> 
     }
 
     // Compare with Output = Option<NodeId>, where you wouldn't know the GroupVars of the child.
-    fn default(&self) -> Self::Output {
+    fn default(&mut self) -> Self::Output {
         self.arena.new_node((IR::Rendered(None), GroupVars::Plain))
     }
     fn fold(&mut self, elements: &[Element], fold_type: WalkerFoldType) -> Self::Output {
@@ -333,10 +333,11 @@ impl<'a, O: OutputFormat, I: OutputFormat> StyleWalker for ProcWalker<'a, O, I> 
             db,
             ctx,
             ref mut state,
+            ref mut arena,
             ..
         } = *self;
         let o: Option<NodeId> = state.maybe_suppress_date(var, |state| {
-            Some(body_date.intermediate(db, state, ctx, self.arena))
+            Some(body_date.intermediate(db, state, ctx, arena))
         });
         o.unwrap_or_else(|| {
             self.arena

--- a/crates/proc/src/element.rs
+++ b/crates/proc/src/element.rs
@@ -141,7 +141,11 @@ where
                                         dropped_gv: None,
                                     };
                                     // the citation-label is important, so so is the seq
-                                    arena.new_node((IR::Seq(seq), GroupVars::Important))
+                                    let seq_node =
+                                        arena.new_node((IR::Seq(seq), GroupVars::Important));
+                                    seq_node.append(label_node, arena);
+                                    seq_node.append(hook_node, arena);
+                                    seq_node
                                 })
                                 .unwrap_or_else(|| {
                                     arena.new_node((IR::Rendered(None), GroupVars::Missing))

--- a/crates/proc/src/group.rs
+++ b/crates/proc/src/group.rs
@@ -88,7 +88,6 @@ impl GroupVars {
     /// ```
     pub fn neighbour(self, other: Self) -> Self {
         match (self, other) {
-
             // if either is Important, the parent group will be too. For sure. Don't need to track
             // Unresolved any further than this.
             (Important, _) | (_, Important) => Important,
@@ -132,7 +131,10 @@ impl GroupVars {
     }
 
     #[inline]
-    pub fn implicit_conditional<T: Default + PartialEq + std::fmt::Debug>(self, ir: T) -> (T, Self) {
+    pub fn implicit_conditional<T: Default + PartialEq + std::fmt::Debug>(
+        self,
+        ir: T,
+    ) -> (T, Self) {
         let default = T::default();
         if self == Missing {
             (default, GroupVars::Missing)
@@ -144,14 +146,7 @@ impl GroupVars {
             // groups.
             //
             // https://discourse.citationstyles.org/t/groups-variables-and-missing-dates/1529/18
-            (
-                ir,
-                if self == Plain {
-                    Important
-                } else {
-                    self
-                }
-            )
+            (ir, if self == Plain { Important } else { self })
         }
     }
 }

--- a/crates/proc/src/helpers.rs
+++ b/crates/proc/src/helpers.rs
@@ -22,9 +22,21 @@ where
     O: OutputFormat,
     I: OutputFormat,
 {
-    sequence(db, state, ctx, arena, els, "".into(), None, None, None, None, TextCase::None, false)
+    sequence(
+        db,
+        state,
+        ctx,
+        arena,
+        els,
+        "".into(),
+        None,
+        None,
+        None,
+        None,
+        TextCase::None,
+        false,
+    )
 }
-
 
 pub fn sequence<'c, O, I>(
     db: &dyn IrDatabase,
@@ -80,11 +92,7 @@ where
             display: if ctx.in_bibliography { display } else { None },
             quotes,
             text_case,
-            dropped_gv: if is_group {
-                Some(dropped_gv)
-            } else {
-                None
-            },
+            dropped_gv: if is_group { Some(dropped_gv) } else { None },
         })
     };
 
@@ -107,9 +115,19 @@ pub fn ref_sequence_basic<'c>(
     els: &[Element],
     stack: Formatting,
 ) -> (RefIR, GroupVars) {
-    ref_sequence(db, state, ctx, els, "".into(), Some(stack), None, None, None, TextCase::None)
+    ref_sequence(
+        db,
+        state,
+        ctx,
+        els,
+        "".into(),
+        Some(stack),
+        None,
+        None,
+        None,
+        TextCase::None,
+    )
 }
-
 
 pub fn ref_sequence<'c>(
     db: &dyn IrDatabase,
@@ -130,7 +148,8 @@ pub fn ref_sequence<'c>(
     // let mut dropped_gv = GroupVars::new();
 
     for el in els {
-        let (ir, gv) = Disambiguation::<Markup>::ref_ir(el, db, ctx, state, formatting.unwrap_or_default());
+        let (ir, gv) =
+            Disambiguation::<Markup>::ref_ir(el, db, ctx, state, formatting.unwrap_or_default());
         match ir {
             RefIR::Edge(None) => {
                 // dropped_gv = dropped_gv.neighbour(gv);
@@ -166,13 +185,10 @@ pub fn fnv_set_with_cap<T: std::hash::Hash + std::cmp::Eq>(cap: usize) -> FnvHas
     FnvHashSet::with_capacity_and_hasher(cap, fnv::FnvBuildHasher::default())
 }
 
-use csl::{Variable, TextElement, StandardVariable, VariableForm, TextCase, TextSource};
+use csl::{StandardVariable, TextCase, TextElement, TextSource, Variable, VariableForm};
 pub fn plain_text_element(v: Variable) -> TextElement {
     TextElement {
-        source: TextSource::Variable(
-            StandardVariable::Ordinary(v),
-            VariableForm::Long,
-        ),
+        source: TextSource::Variable(StandardVariable::Ordinary(v), VariableForm::Long),
         formatting: None,
         affixes: None,
         quotes: false,
@@ -181,4 +197,3 @@ pub fn plain_text_element(v: Variable) -> TextElement {
         display: None,
     }
 }
-

--- a/crates/proc/src/helpers.rs
+++ b/crates/proc/src/helpers.rs
@@ -57,7 +57,6 @@ where
     O: OutputFormat,
     I: OutputFormat,
 {
-    let mut contents = Vec::with_capacity(els.len());
     let mut overall_gv = GroupVars::new();
     let mut dropped_gv = GroupVars::new();
 
@@ -70,6 +69,7 @@ where
     for el in els {
         let child = el.intermediate(db, state, ctx, arena);
         let ch = arena.get(child).unwrap().get();
+        let gv = ch.1;
         match ch.0 {
             IR::Rendered(None) => {
                 dropped_gv = dropped_gv.neighbour(gv);
@@ -82,7 +82,7 @@ where
         }
     }
 
-    let ir = if contents.is_empty() {
+    let ir = if self_node.children(arena).next().is_none() {
         IR::Rendered(None)
     } else {
         IR::Seq(IrSeq {

--- a/crates/proc/src/helpers.rs
+++ b/crates/proc/src/helpers.rs
@@ -15,13 +15,14 @@ pub fn sequence_basic<'c, O, I>(
     db: &dyn IrDatabase,
     state: &mut IrState,
     ctx: &CiteContext<'c, O, I>,
+    arena: &mut IrArena<O>,
     els: &[Element],
-) -> IrSum<O>
+) -> NodeId
 where
     O: OutputFormat,
     I: OutputFormat,
 {
-    sequence(db, state, ctx, els, "".into(), None, None, None, None, TextCase::None, false)
+    sequence(db, state, ctx, arena, els, "".into(), None, None, None, None, TextCase::None, false)
 }
 
 
@@ -29,6 +30,7 @@ pub fn sequence<'c, O, I>(
     db: &dyn IrDatabase,
     state: &mut IrState,
     ctx: &CiteContext<'c, O, I>,
+    arena: &mut IrArena<O>,
     els: &[Element],
     delimiter: Atom,
     formatting: Option<Formatting>,
@@ -38,7 +40,7 @@ pub fn sequence<'c, O, I>(
     quotes: Option<LocalizedQuotes>,
     text_case: TextCase,
     is_group: bool,
-) -> IrSum<O>
+) -> NodeId
 where
     O: OutputFormat,
     I: OutputFormat,
@@ -47,15 +49,22 @@ where
     let mut overall_gv = GroupVars::new();
     let mut dropped_gv = GroupVars::new();
 
+    // We will edit this later if it turns out it has content & isn't discarded
+    let self_node = arena.new_node((IR::Rendered(None), GroupVars::Plain));
+    if els.is_empty() {
+        return self_node;
+    }
+
     for el in els {
-        let (ir, gv) = el.intermediate(db, state, ctx);
-        match ir {
+        let child = el.intermediate(db, state, ctx, arena);
+        let ch = arena.get(child).unwrap().get();
+        match ch.0 {
             IR::Rendered(None) => {
                 dropped_gv = dropped_gv.neighbour(gv);
                 overall_gv = overall_gv.neighbour(gv);
             }
             _ => {
-                contents.push((ir, gv));
+                self_node.append(child, arena);
                 overall_gv = overall_gv.neighbour(gv)
             }
         }
@@ -65,7 +74,6 @@ where
         IR::Rendered(None)
     } else {
         IR::Seq(IrSeq {
-            contents,
             formatting,
             affixes: affixes.cloned(),
             delimiter,
@@ -79,11 +87,17 @@ where
             },
         })
     };
-    if is_group {
+
+    let (set_ir, set_gv) = if is_group {
         overall_gv.implicit_conditional(ir)
     } else {
         (ir, overall_gv)
-    }
+    };
+
+    let (self_ir, self_gv) = arena.get_mut(self_node).unwrap().get_mut();
+    *self_ir = set_ir;
+    *self_gv = set_gv;
+    self_node
 }
 
 pub fn ref_sequence_basic<'c>(

--- a/crates/proc/src/ir.rs
+++ b/crates/proc/src/ir.rs
@@ -360,7 +360,7 @@ impl IR<Markup> {
                 edges.push(ed.to_edge_data(fmt, formatting))
             }
             IR::YearSuffix(ys) => {
-                if IR::is_empty(node, arena) {
+                if !IR::is_empty(node, arena) {
                     edges.push(EdgeData::YearSuffix);
                 }
             }

--- a/crates/proc/src/ir.rs
+++ b/crates/proc/src/ir.rs
@@ -203,7 +203,7 @@ where
         match &me.0 {
             IR::Rendered(None) => true,
             IR::Seq(_) | IR::Name(_) | IR::ConditionalDisamb(_) | IR::YearSuffix(_) => {
-                node.children(arena).next().is_some()
+                node.children(arena).next().is_none()
             }
             IR::NameCounter(nc) => false,
             _ => false,

--- a/crates/proc/src/ir/transforms.rs
+++ b/crates/proc/src/ir/transforms.rs
@@ -1,45 +1,41 @@
-use crate::disamb::names::NameIR;
+use crate::disamb::names::{NameIr, replace_single_child};
 use crate::names::NameToken;
 use crate::prelude::*;
 use citeproc_io::Cite;
 use csl::Atom;
 use std::mem;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 /////////////////////////////////
 // capitalize start of cluster //
 /////////////////////////////////
 
 impl<O: OutputFormat> IR<O> {
-    pub fn capitalize_first_term_of_cluster(&mut self, fmt: &O) {
+    pub fn capitalize_first_term_of_cluster(root: NodeId, arena: &mut IrArena<O>, fmt: &O) {
         if let Some(trf) = self.find_term_rendered_first() {
-            fmt.apply_text_case(trf, &IngestOptions {
-                text_case: TextCase::CapitalizeFirst,
-                ..Default::default()
-            });
+            fmt.apply_text_case(
+                trf,
+                &IngestOptions {
+                    text_case: TextCase::CapitalizeFirst,
+                    ..Default::default()
+                },
+            );
         }
     }
     // Gotta find a a CiteEdgeData::Term/LocatorLabel/FrnnLabel
     // (the latter two are also terms, but a different kind for disambiguation).
-    fn find_term_rendered_first(&mut self) -> Option<&mut O::Build> {
-        match self {
-            IR::Rendered(Some(CiteEdgeData::Term(b))) |
-            IR::Rendered(Some(CiteEdgeData::LocatorLabel(b))) |
-            IR::Rendered(Some(CiteEdgeData::FrnnLabel(b))) => Some(b),
-            // IR::ConditionalDisamb(c) => {
-            //     let mut lock = c.lock().unwrap();
-            //     lock.ir.find_term_rendered_first()
-            // }
-            IR::Seq(seq) => {
-                // Search backwards because it's likely to be near the end
-                seq.contents
-                    .first_mut()
-                    .and_then(|(ir, _)| ir.find_term_rendered_first())
-            }
+    fn find_term_rendered_first(node: NodeId, arena: &mut IrArena<O>) -> Option<&mut O::Build> {
+        match arena.get_mut(node)?.get_mut().0 {
+            IR::Rendered(Some(CiteEdgeData::Term(b)))
+                | IR::Rendered(Some(CiteEdgeData::LocatorLabel(b)))
+                | IR::Rendered(Some(CiteEdgeData::FrnnLabel(b))) => Some(&mut b),
+            IR::ConditionalDisamb(_) | IR::Seq(_) => node
+                .children(arena)
+                .next()
+                .and_then(|child| IR::find_term_rendered_first(child, arena)),
             _ => None,
         }
     }
-
 }
 
 ////////////////////////
@@ -47,67 +43,81 @@ impl<O: OutputFormat> IR<O> {
 ////////////////////////
 
 impl<O: OutputFormat> IR<O> {
-    pub fn split_first_field(&mut self) {
+    // If returns Some(id), that ID is the new root node of the whole tree.
+    pub fn split_first_field(node: NodeId, arena: &mut IrArena<O>) -> Option<NodeId> {
         // Pull off the first field of self -> [first, ...rest]
-        if let Some(((first, gv), mut rest)) = match self {
-            IR::Seq(seq) => if seq.contents.len() > 1 {
-                Some(seq.contents.remove(0))
-            } else {
-                None
+        if let Some((first, orig_top_seq)) = match arena.get_mut(node)?.get_mut().0 {
+            // I.e. if there are at least two child nodes
+            IR::Seq(ref mut seq) if node.children(arena).take(2).count() == 2 => {
+                node.children(arena).next().and_then(|f| {
+                    f.detach(arena);
+                    Some((f, mem::take(seq)))
+                })
             }
-            .and_then(|f| Some((f, mem::take(seq)))),
             _ => None,
         } {
-            rest.display = Some(DisplayMode::RightInline);
+            // First is now detached. Node has the remaining children.
+            let right = node;
+            let (afpre, afsuf) = {
+                // Keep this mutable ref inside {}
+                // Split the affixes into two sets with empty inside.
+                orig_top_seq
+                    .affixes
+                    .map(|mine| {
+                        (
+                            Some(Affixes {
+                                prefix: mine.prefix,
+                                suffix: Atom::from(""),
+                            }),
+                            Some(Affixes {
+                                prefix: Atom::from(""),
+                                suffix: mine.suffix,
+                            }),
+                        )
+                    })
+                .unwrap_or((None, None))
+            };
 
-            // Split the affixes into two sets with empty inside.
-            let (afpre, afsuf) = rest
-                .affixes
-                .map(|mine| {
-                    (
-                        Some(Affixes {
-                            prefix: mine.prefix,
-                            suffix: Atom::from(""),
-                        }),
-                        Some(Affixes {
-                            prefix: Atom::from(""),
-                            suffix: mine.suffix,
-                        }),
-                    )
-                })
-                .unwrap_or((None, None));
+            let left_gv = arena.get(first)?.get().1;
+            let left = arena.new_node((
+                    IR::Seq(IrSeq {
+                        display: Some(DisplayMode::LeftMargin),
+                        affixes: afpre,
+                        ..Default::default()
+                    }),
+                    left_gv,
+            ));
 
-            // Replace with joined splits
-            *self = IR::Seq(IrSeq {
-                contents: vec![
-                    (
-                        IR::Seq(IrSeq {
-                            contents: vec![(first, gv)],
-                            display: Some(DisplayMode::LeftMargin),
-                            affixes: afpre,
-                            ..Default::default()
-                        }),
-                        gv,
-                    ),
-                    (
-                        IR::Seq(IrSeq {
-                            contents: rest.contents,
-                            display: Some(DisplayMode::RightInline),
-                            affixes: afsuf,
-                            ..Default::default()
-                        }),
-                        GroupVars::Important,
-                    ),
-                ],
+            let right_config = (
+                IR::Seq(IrSeq {
+                    display: Some(DisplayMode::RightInline),
+                    affixes: afsuf,
+                    ..Default::default()
+                }),
+                GroupVars::Important,
+            );
+
+            // Take the IrSeq that configured the original top-level.
+            // Replace the configuration for rest/right-hand-side with right_config.
+            // This is because we want to move all of the rest node's children to the right hand
+            // side, so the node is the thing that has to move.
+            *arena.get(right)?.get_mut() = right_content;
+            top_seq.0 = IR::Seq(IrSeq {
                 display: None,
-                formatting: rest.formatting,
                 affixes: None,
-                delimiter: rest.delimiter.clone(),
                 dropped_gv: None,
-                quotes: rest.quotes.clone(),
-                text_case: rest.text_case,
+                ..orig_top_seq
             });
+
+            // Twist it all into place.
+            // We make sure right is detached, even though ATM it's definitely a detached node.
+            let new_toplevel = arena.new_node(top_seq);
+            right.detach(arena);
+            new_toplevel.append(left, arena);
+            new_toplevel.append(right, arena);
+            return Some(new_toplevel);
         }
+        return None;
     }
 }
 
@@ -116,190 +126,178 @@ impl<O: OutputFormat> IR<O> {
 ////////////////////////////////
 
 impl<O: OutputFormat> IR<O> {
-    pub fn first_name_block(&self) -> Option<Arc<Mutex<NameIR<O>>>> {
-        match self {
-            IR::Name(ref nir) => Some(nir.clone()),
-            IR::ConditionalDisamb(c) => {
-                let lock = c.lock().unwrap();
-                lock.ir.first_name_block()
-            }
-            IR::Seq(seq) => {
+    pub fn first_name_block(node: NodeId, arena: &IrArena<O>) -> Option<NodeId> {
+        match arena.get(node)?.get().0 {
+            IR::Name(_) => Some(node),
+            IR::ConditionalDisamb(_) | IR::Seq(_) => {
                 // assumes it's the first one that appears
-                seq.contents.iter().find_map(|ir| ir.0.first_name_block())
+                node.children(arena)
+                    .find_map(|child| IR::first_name_block(child, arena))
             }
             _ => None,
         }
     }
 
-    fn find_locator(&self) -> bool {
-        match self {
-            IR::Rendered(Some(CiteEdgeData::Locator(_))) => true,
-            IR::ConditionalDisamb(c) => {
-                let mut lock = c.lock().unwrap();
-                lock.ir.find_locator()
-            }
-            IR::Seq(seq) => {
+    fn find_locator(node: NodeId, arena: &IrArena<O>) -> Option<NodeId> {
+        match arena.get(node)?.get().0 {
+            IR::Rendered(Some(CiteEdgeData::Locator(_))) => Some(node),
+            IR::ConditionalDisamb(_) | IR::Seq(_) => {
                 // Search backwards because it's likely to be near the end
-                seq.contents
-                    .iter()
-                    .rfind(|(ir, _)| ir.find_locator())
-                    .is_some()
+                node.reverse_children(arena)
+                    .find_map(|child| IR::find_locator(child, arena))
             }
-            _ => false,
-        }
-    }
-
-    fn find_first_year(&self) -> Option<O::Build> {
-        match self {
-            IR::Rendered(Some(CiteEdgeData::Year(b))) => Some(b.clone()),
-            IR::ConditionalDisamb(c) => {
-                let mut lock = c.lock().unwrap();
-                lock.ir.find_first_year()
-            }
-            IR::Seq(seq) => seq.contents.iter().find_map(|(ir, _)| ir.find_first_year()),
             _ => None,
         }
     }
 
-    fn find_first_year_and_suffix(&self) -> Option<(O::Build, u32)> {
-        if let Some(fy) = self.find_first_year() {
-            debug!("fy, {:?}", fy);
+    fn find_first_year(node: NodeId, arena: &IrArena<O>) -> Option<NodeId> {
+        match arena.get(node)?.get().0 {
+            IR::Rendered(Some(CiteEdgeData::Year(b))) => Some(node),
+            IR::Seq(_) | IR::ConditionalDisamb(_) => node
+                .children(arena)
+                .find_map(|child| IR::find_first_year(child, arena)),
+            _ => None,
         }
-        if let Some(ys) = self.find_year_suffix() {
-            debug!("ys, {:?}", ys);
-        }
-        Some((self.find_first_year()?, self.find_year_suffix()?))
+    }
+
+    pub fn find_year_suffix(node: NodeId, arena: &IrArena<O>) -> Option<u32> {
+        IR::has_implicit_year_suffix(node, arena)
+            .or_else(|| IR::has_explicit_year_suffix(node, arena))
+    }
+
+    fn find_first_year_and_suffix(node: NodeId, arena: &IrArena<O>) -> Option<(NodeId, u32)> {
+        // if let Some(fy) = IR::find_first_year(node, arena) {
+        //     debug!("fy, {:?}", fy);
+        // }
+        // if let Some(ys) = IR::find_year_suffix(node, arena) {
+        //     debug!("ys, {:?}", ys);
+        // }
+        Some((
+                IR::find_first_year(node, arena)?,
+                IR::find_year_suffix(node, arena)?,
+        ))
     }
 
     /// Rest of the name: "if it has a year suffix"
-    fn suppress_first_year(&mut self, has_explicit: bool) -> bool {
-        match self {
-            IR::Rendered(opt @ Some(CiteEdgeData::Year(_))) => {
-                *opt = None;
-                true
+    fn suppress_first_year(node: NodeId, arena: &mut IrArena<O>, has_explicit: bool) -> Option<NodeId> {
+        match arena.get(node)?.get().0 {
+            IR::Rendered(Some(CiteEdgeData::Year(_))) => {
+                arena.get_mut(node)?.get_mut().0 = IR::Rendered(None);
+                Some(node)
             }
-            IR::ConditionalDisamb(c) => {
-                let mut lock = c.lock().unwrap();
-                lock.ir.suppress_first_year(has_explicit);
-                false
+            IR::ConditionalDisamb(_) => {
+                // Not sure why this result is thrown away
+                IR::suppress_first_year(node, arena, has_explicit);
+                None
             }
-            IR::Seq(seq) => {
-                let mut found = if seq.contents.len() == 2 {
-                    if let ((first, _), (second, gv)) = pair_at_mut(&mut seq.contents, 0).unwrap() {
-                        match (second, gv) {
-                            (IR::YearSuffix(_), GroupVars::Unresolved) if has_explicit => {
-                                first.suppress_first_year(has_explicit)
-                            }
-                            (IR::YearSuffix(ys), GroupVars::Important)
-                                if !has_explicit && !ys.ir.is_empty() =>
-                            {
-                                first.suppress_first_year(has_explicit)
-                            }
-                            _ => false,
+            IR::Seq(_) => {
+                let mut iter = node.children(arena).fuse();
+                let first_two = (iter.next(), iter.next());
+                if iter.next().is_some() {
+                    return None;
+                }
+                // Check for the exact explicit year suffix IR output
+                let mut found = if let (Some(first), Some(second)) = first_two {
+                    match arena.get(second).unwrap().get() {
+                        (IR::YearSuffix(_), GroupVars::Unresolved) if has_explicit => {
+                            IR::suppress_first_year(first, arena, has_explicit)
                         }
-                    } else {
-                        false
+                        (IR::YearSuffix(_), GroupVars::Important)
+                            if !has_explicit && second.children(arena).next().is_some() =>
+                            {
+                                IR::suppress_first_year(first, arena, has_explicit)
+                            }
+                        _ => None,
                     }
                 } else {
-                    false
+                    None
                 };
-                if !found {
-                    for (ir, _) in seq.contents.iter_mut() {
-                        if ir.suppress_first_year(has_explicit) {
-                            found = true;
+
+                // Otherwise keep looking in subtrees etc
+                if found.is_none() {
+                    let child_ids: Vec<_> = node.children(arena).collect();
+                    for child in child_ids {
+                        found = IR::suppress_first_year(child, arena, has_explicit);
+                        if found.is_some() {
                             break;
                         }
                     }
                 }
                 found
             }
-            _ => false,
+            _ => None,
         }
     }
 
-    pub fn find_year_suffix(&self) -> Option<u32> {
-        self.has_implicit_year_suffix()
-            .or_else(|| self.has_explicit_year_suffix())
-    }
-
-    pub fn has_implicit_year_suffix(&self) -> Option<u32> {
-        match self {
+    pub fn has_implicit_year_suffix(node: NodeId, arena: &IrArena<O>) -> Option<u32> {
+        match arena.get(node)?.get().0 {
             IR::YearSuffix(YearSuffix {
                 hook: YearSuffixHook::Plain,
-                ir,
                 suffix_num: Some(n),
                 ..
-            }) if !ir.is_empty() => Some(*n),
-            IR::ConditionalDisamb(c) => {
-                let lock = c.lock().unwrap();
-                lock.ir.has_implicit_year_suffix()
-            }
-            IR::Seq(seq) => {
+            }) if IR::is_empty(node, arena) => Some(n),
+
+            IR::ConditionalDisamb(_) | IR::Seq(_) => {
                 // assumes it's the first one that appears
-                seq.contents
-                    .iter()
-                    .find_map(|ir| ir.0.has_implicit_year_suffix())
+                node.children(arena)
+                    .find_map(|child| IR::has_implicit_year_suffix(child, arena))
             }
             _ => None,
         }
     }
 
-    pub fn has_explicit_year_suffix(&self) -> Option<u32> {
-        match self {
+    pub fn has_explicit_year_suffix(node: NodeId, arena: &IrArena<O>) -> Option<u32> {
+        match arena.get(node)?.get().0 {
             IR::YearSuffix(YearSuffix {
                 hook: YearSuffixHook::Explicit(_),
-                ir,
                 suffix_num: Some(n),
                 ..
-            }) if !ir.is_empty() => Some(*n),
-            IR::ConditionalDisamb(c) => {
-                let lock = c.lock().unwrap();
-                lock.ir.has_explicit_year_suffix()
-            }
-            IR::Seq(seq) => {
+            }) if IR::is_empty(node, arena) => Some(n),
+
+            IR::ConditionalDisamb(_) | IR::Seq(_) => {
                 // assumes it's the first one that appears
-                seq.contents
-                    .iter()
-                    .find_map(|ir| ir.0.has_explicit_year_suffix())
+                node.children(arena)
+                    .find_map(|child| IR::has_explicit_year_suffix(child, arena))
             }
             _ => None,
         }
     }
 
-    pub fn suppress_names(&self) {
-        if let Some(fnb) = self.first_name_block() {
-            let mut guard = fnb.lock().unwrap();
-            *guard.ir = IR::Rendered(None);
+    pub fn suppress_names(node: NodeId, arena: &mut IrArena<O>) {
+        if let Some(fnb) = IR::first_name_block(node, arena) {
+            // TODO: check interaction of this with GroupVars of the parent seq
+            fnb.remove_subtree(arena);
         }
     }
-    pub fn suppress_year(&mut self) {
-        let has_explicit = self.has_explicit_year_suffix().is_some();
-        if !has_explicit && self.has_implicit_year_suffix().is_none() {
+
+    pub fn suppress_year(node: NodeId, arena: &mut IrArena<O>) {
+        let has_explicit = IR::has_explicit_year_suffix(node, arena).is_some();
+        let has_implicit = IR::has_implicit_year_suffix(node, arena).is_some();
+        if !has_explicit && !has_implicit {
             return;
         }
-        self.suppress_first_year(has_explicit);
+        IR::suppress_first_year(node, arena, has_explicit);
     }
 }
 
 impl<O: OutputFormat<Output = String>> IR<O> {
-    pub fn collapse_to_cnum(&self, fmt: &O) -> Option<u32> {
-        match self {
+    pub fn collapse_to_cnum(node: NodeId, arena: &IrArena<O>, fmt: &O) -> Option<u32> {
+        match arena.get(node)?.get().0 {
             IR::Rendered(Some(CiteEdgeData::CitationNumber(build))) => {
                 // TODO: just get it from the database
                 fmt.output(build.clone(), false).parse().ok()
             }
-            IR::ConditionalDisamb(c) => {
-                let lock = c.lock().unwrap();
-                lock.ir.collapse_to_cnum(fmt)
+            IR::ConditionalDisamb(_) => {
+                node.children(arena).find_map(|child| IR::collapse_to_cnum(child, arena, fmt))
             }
-            IR::Seq(seq) => {
+            IR::Seq(_) => {
                 // assumes it's the first one that appears
-                if seq.contents.len() != 1 {
+                if node.children(arena).count() != 1 {
                     None
                 } else {
-                    seq.contents
-                        .first()
-                        .and_then(|(x, _)| x.collapse_to_cnum(fmt))
+                    node.children(arena)
+                        .next()
+                        .and_then(|child| IR::collapse_to_cnum(child, arena, fmt))
                 }
             }
             _ => None,
@@ -397,8 +395,8 @@ fn range_collapse() {
     assert_eq!(
         collapse_ranges(&[s(1), s(2), CnumIx::new(4, 3)]),
         vec![
-            RangePiece::Range(s(1), s(2)),
-            RangePiece::Single(CnumIx::new(4, 3))
+        RangePiece::Range(s(1), s(2)),
+        RangePiece::Single(CnumIx::new(4, 3))
         ]
     );
 }
@@ -442,7 +440,8 @@ impl Debug for Unnamed3<Markup> {
             .field("cnum", &self.cnum)
             .field(
                 "gen4",
-                &self.gen4.ir.flatten(&fmt).map(|x| fmt.output(x, false)),
+                &IR::flatten(self.gen4.root, &self.gen4.arena, fmt)
+                    .map(|x| fmt.output(x, false)),
             )
             .field("has_locator", &self.has_locator)
             .field("is_first", &self.is_first)
@@ -453,7 +452,7 @@ impl Debug for Unnamed3<Markup> {
             .field("collapsed_year_suffixes", &self.collapsed_year_suffixes)
             .field("collapsed_ranges", &self.collapsed_ranges)
             .field("vanished", &self.vanished)
-            .field("gen4_full", &self.gen4.ir)
+            .field("gen4_full", &self.gen4.arena)
             .finish()
     }
 }
@@ -461,7 +460,8 @@ impl Debug for Unnamed3<Markup> {
 impl<O: OutputFormat> Unnamed3<O> {
     pub fn new(cite: Arc<Cite<O>>, cnum: Option<u32>, gen4: Arc<IrGen>) -> Self {
         Unnamed3 {
-            has_locator: cite.locators.is_some() && gen4.ir.find_locator(),
+            has_locator: cite.locators.is_some()
+                && IR::find_locator(gen4.root, &gen4.arena).is_some(),
             cite,
             gen4,
             cnum,
@@ -493,11 +493,8 @@ pub fn group_and_collapse<O: OutputFormat<Output = String>>(
 
     // First, group cites with the same name
     for ix in 0..cites.len() {
-        let rendered = cites[ix]
-            .gen4
-            .ir
-            .first_name_block()
-            .and_then(|fnb| fnb.lock().unwrap().ir.flatten(fmt))
+        let rendered = IR::first_name_block(cites[ix].gen4.root, &cites[ix].gen4.arena)
+            .and_then(|fnb| IR::flatten(fnb, arena, fmt))
             .map(|flat| fmt.output(flat, false));
         same_names
             .entry(rendered)
@@ -505,8 +502,8 @@ pub fn group_and_collapse<O: OutputFormat<Output = String>>(
                 // Keep cites separated by affixes together
                 if cites.get(*oix).map_or(false, |u| u.cite.has_suffix())
                     || cites.get(*oix + 1).map_or(false, |u| u.cite.has_prefix())
-                    || cites.get(ix - 1).map_or(false, |u| u.cite.has_suffix())
-                    || cites.get(ix).map_or(false, |u| u.cite.has_affix())
+                        || cites.get(ix - 1).map_or(false, |u| u.cite.has_suffix())
+                        || cites.get(ix).map_or(false, |u| u.cite.has_affix())
                 {
                     *oix = ix;
                     *seen_once = false;
@@ -523,8 +520,8 @@ pub fn group_and_collapse<O: OutputFormat<Output = String>>(
                     *oix += 1;
                 }
             })
-            .or_insert((ix, false));
-    }
+        .or_insert((ix, false));
+        }
 
     if collapse.map_or(false, |c| {
         c == Collapse::YearSuffixRanged || c == Collapse::YearSuffix
@@ -539,12 +536,13 @@ pub fn group_and_collapse<O: OutputFormat<Output = String>>(
                         break;
                     }
                     moved += 1;
-                    if let Some((y, suf)) = cites[ix]
-                        .gen4
-                        .ir
-                        .find_first_year_and_suffix()
-                        .map(|(y, suf)| (fmt.output(y, false), suf))
-                    {
+                    let year_and_suf =
+                        IR::find_first_year_and_suffix(cites[ix].gen4.root, &cites[ix].gen4.arena)
+                        .and_then(|(ys_node, suf)| {
+                            let flat = IR::flatten(ys_node, &cites[ix].gen4.arena, fmt)?;
+                            Some((fmt.output(flat, false), suf))
+                        });
+                    if let Some((y, suf)) = year_and_suf {
                         cites[ix].year_suffix = Some(suf);
                         same_years
                             .entry(y)
@@ -560,8 +558,8 @@ pub fn group_and_collapse<O: OutputFormat<Output = String>>(
                                 }
                                 *oix = ix;
                             })
-                            .or_insert((ix, false));
-                    }
+                        .or_insert((ix, false));
+                        }
                     ix += 1;
                 }
                 top_ix += moved;
@@ -623,7 +621,7 @@ pub fn group_and_collapse<O: OutputFormat<Output = String>>(
                             let mut count = 0;
                             for (nix, cite) in following.enumerate() {
                                 let gen4 = Arc::make_mut(&mut cite.gen4);
-                                gen4.ir.suppress_names();
+                                IR::suppress_names(gen4.root, &mut gen4.arena);
                                 count += 1;
                             }
                             ix += count;
@@ -641,7 +639,7 @@ pub fn group_and_collapse<O: OutputFormat<Output = String>>(
                             let following = rest.iter_mut().take_while(|u| u.should_collapse);
                             for (nix, cite) in following.enumerate() {
                                 let gen4 = Arc::make_mut(&mut cite.gen4);
-                                gen4.ir.suppress_names();
+                                IR::suppress_names(gen4.root, &mut gen4.arena)
                             }
                         }
                         if u.first_of_ys {
@@ -664,7 +662,7 @@ pub fn group_and_collapse<O: OutputFormat<Output = String>>(
                                     cite.vanished = true;
                                     if !cite.has_locator {
                                         let gen4 = Arc::make_mut(&mut cite.gen4);
-                                        gen4.ir.suppress_year();
+                                        IR::suppress_year(gen4.root, &mut gen4.arena);
                                     }
                                 }
                                 u.collapsed_year_suffixes = collapse_ranges(&cnums);
@@ -676,16 +674,16 @@ pub fn group_and_collapse<O: OutputFormat<Output = String>>(
                                 for (nix, cite) in following.enumerate() {
                                     if let Some(cnum) = cite.year_suffix {
                                         u.collapsed_year_suffixes.push(RangePiece::Single(
-                                            CnumIx {
-                                                cnum,
-                                                ix: ix + nix + 1,
-                                                force_single: cite.has_locator,
-                                            },
+                                                CnumIx {
+                                                    cnum,
+                                                    ix: ix + nix + 1,
+                                                    force_single: cite.has_locator,
+                                                },
                                         ));
                                     }
                                     cite.vanished = true;
                                     let gen4 = Arc::make_mut(&mut cite.gen4);
-                                    gen4.ir.suppress_year();
+                                    IR::suppress_year(gen4.root, &mut gen4.arena);
                                 }
                             }
                         }
@@ -713,9 +711,9 @@ fn pair_at_mut<T>(mut slice: &mut [T], ix: usize) -> Option<(&mut T, &mut T)> {
 // Cite Grouping & Collapsing //
 ////////////////////////////////
 
-use csl::SubsequentAuthorSubstituteRule as SasRule;
+use crate::disamb::names::DisambNameRatchet;
 use citeproc_io::PersonName;
-use crate::disamb::names::{DisambNameRatchet, PersonDisambNameRatchet};
+use csl::SubsequentAuthorSubstituteRule as SasRule;
 
 #[derive(Eq, PartialEq, Clone)]
 pub enum ReducedNameToken<'a, B> {
@@ -728,7 +726,7 @@ pub enum ReducedNameToken<'a, B> {
     Space,
 }
 
-impl<'a, T: Debug>  Debug for ReducedNameToken<'a, T> {
+impl<'a, T: Debug> Debug for ReducedNameToken<'a, T> {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             ReducedNameToken::Name(p) => write!(f, "{:?}", p.family),
@@ -742,13 +740,13 @@ impl<'a, T: Debug>  Debug for ReducedNameToken<'a, T> {
     }
 }
 
-impl<'a, T> ReducedNameToken<'a, T> {
-    fn from_token(token: &NameToken<'a, T>) -> Self {
+impl<'a> ReducedNameToken<'a, T> {
+    fn from_token(token: &NameToken, names: &'a [DisambNameRatchet<T>]) -> Self {
         match token {
-            NameToken::Name(dnr) => match dnr {
+            NameToken::Name(dnr_index) => match &names[dnr_index] {
                 DisambNameRatchet::Person(p) => ReducedNameToken::Name(&p.data.value),
                 DisambNameRatchet::Literal(b) => ReducedNameToken::Literal(b),
-            }
+            },
             NameToken::Ellipsis => ReducedNameToken::Ellipsis,
             NameToken::EtAl(..) => ReducedNameToken::EtAl,
             NameToken::Space => ReducedNameToken::Space,
@@ -764,68 +762,113 @@ impl<'a, T> ReducedNameToken<'a, T> {
     }
 }
 
+impl<O: OutputFormat> IR<O> {
+    fn unwrap_name_ir(&self) -> &mut NameIR<O> {
+        match self {
+            IR::Name(nir) => nir,
+            _ => panic!("Called unwrap_name_ir on a {:?}", self),
+        }
+    }
+    fn unwrap_name_ir_mut(&mut self) -> &mut NameIR<O> {
+        match self {
+            IR::Name(nir) => nir,
+            _ => panic!("Called unwrap_name_ir_mut on a {:?}", self),
+        }
+    }
+}
+
 pub fn subsequent_author_substitute<O: OutputFormat>(
     fmt: &O,
-    previous: &Mutex<NameIR<O>>,
-    current: &Mutex<NameIR<O>>,
+    previous: &NameIR<O>,
+    current_id: NodeId,
+    arena: &mut IrArena<O>,
     sas: &str,
     sas_rule: SasRule,
 ) -> bool {
-    let pre = previous.lock().unwrap();
-    let mut cur = current.lock().unwrap();
-    let pre_tokens = pre.iter_bib_rendered_names(fmt);
+    let pre_tokens = previous.iter_bib_rendered_names(fmt);
     let pre_reduced = pre_tokens
         .iter()
-        .map(ReducedNameToken::from_token)
+        .map(|tok| ReducedNameToken::from_token(tok, &previous.disamb_names))
         .filter(|x| x.relevant());
+    let cur = arena.get(current_id).unwrap().get().0.unwrap_name_ir();
     let cur_tokens = cur.iter_bib_rendered_names(fmt);
     let cur_reduced = cur_tokens
         .iter()
-        .map(ReducedNameToken::from_token)
+        .map(|tok| ReducedNameToken::from_token(tok, &cur.disamb_names))
         .filter(|x| x.relevant());
-    debug!("{:?} vs {:?}", pre_reduced.clone().collect::<Vec<_>>(), cur_reduced.clone().collect::<Vec<_>>());
+    debug!(
+        "{:?} vs {:?}",
+        pre_reduced.clone().collect::<Vec<_>>(),
+        cur_reduced.clone().collect::<Vec<_>>()
+    );
     match sas_rule {
         SasRule::CompleteAll | SasRule::CompleteEach => {
             if Iterator::eq(pre_reduced, cur_reduced) {
+                let (current_ir, current_gv) = arena.get_mut(current_id).unwrap().get_mut();
                 if sas_rule == SasRule::CompleteEach {
+                    let current_nir = current_ir.unwrap_name_ir_mut();
                     // let nir handle it
                     // u32::MAX so ALL names get --- treatment
-                    cur.subsequent_author_substitute(fmt, std::u32::MAX, sas);
+                    if let Some(subbed) = current_nir.subsequent_author_substitute(fmt, std::u32::MAX, sas) {
+                        replace_single_child(current_id, arena.new_node(subbed), arena);
+                    }
                 } else if sas.is_empty() {
-                    *cur.ir = IR::Rendered(None)
+                    *current_ir = IR::Rendered(None);
                 } else {
-                    let sas_ir = IR::Rendered(Some(CiteEdgeData::Output(fmt.plain(sas))));
                     let mut contents = vec![(sas_ir, GroupVars::Important)];
-                    if let Some(label_el) = cur.names_inheritance.label.as_ref() {
-                        if let Some(label) = cur.built_label.as_ref() {
-                            let label_ir = IR::Rendered(Some(CiteEdgeData::Output(label.clone())));
+                    *current_ir = IR::Seq(IrSeq::default());
+
+                    // Remove all children
+                    let children: Vec<_> = current_id.children(arena).collect();
+                    children.into_iter().for_each(|ch| ch.remove_subtree(arena));
+
+                    // Add the sas ---
+                    let sas_ir = arena.new_node((
+                        IR::Rendered(Some(CiteEdgeData::Output(fmt.plain(sas)))),
+                        GroupVars::Important
+                    ));
+                    current_id.append(sas_ir, arena);
+
+                    // Add a name label
+                    if let Some(label_el) = current.names_inheritance.label.as_ref() {
+                        if let Some(label) = current.built_label.as_ref() {
+                            let label_node = arena.new_node((
+                                IR::Rendered(Some(CiteEdgeData::Output(label.clone()))),
+                                GroupVars::Plain
+                            ));
                             if label_el.after_name {
-                                contents.push((label_ir, GroupVars::Plain));
+                                current_id.append(label_node, arena)
                             } else {
-                                contents.insert(0, (label_ir, GroupVars::Plain));
+                                current_id.prepend(label_node, arena)
                             }
                         }
                     }
-                    *cur.ir = IR::Seq(IrSeq {
-                        contents,
-                        ..Default::default()
-                    })
                 };
                 return true;
             }
         }
         SasRule::PartialEach => {
-            let count = pre_reduced.zip(cur_reduced)
+            let count = pre_reduced
+                .zip(cur_reduced)
                 .take_while(|(p, c)| p == c)
                 .count();
-            cur.subsequent_author_substitute(fmt, count as u32, sas);
+            let current = arena.get_mut(current_id).unwrap().get_mut();
+            let current_nir = current.0.unwrap_name_ir_mut();
+            if let Some(subbed) = current_nir.subsequent_author_substitute(fmt, count as u32, sas) {
+                replace_single_child(current_id, arena.new_node(subbed), arena);
+            }
         }
         SasRule::PartialFirst => {
-            let count = pre_reduced.zip(cur_reduced)
+            let count = pre_reduced
+                .zip(cur_reduced)
                 .take_while(|(p, c)| p == c)
                 .count();
             if count > 0 {
-                cur.subsequent_author_substitute(fmt, 1, sas);
+                let current = arena.get_mut(current_id).unwrap().get_mut();
+                let current_nir = current.0.unwrap_name_ir_mut();
+                if let Some(subbed) = current_nir.subsequent_author_substitute(fmt, 1, sas) {
+                    replace_single_child(current_id, arena.new_node(subbed), arena);
+                }
             }
         }
     }

--- a/crates/proc/src/ir/transforms.rs
+++ b/crates/proc/src/ir/transforms.rs
@@ -99,6 +99,7 @@ impl<O: OutputFormat> IR<O> {
             }),
             left_gv,
         ));
+        left.append(first, arena);
 
         let right_config = (
             IR::Seq(IrSeq {

--- a/crates/proc/src/ir/transforms.rs
+++ b/crates/proc/src/ir/transforms.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 
 impl<O: OutputFormat> IR<O> {
     pub fn capitalize_first_term_of_cluster(root: NodeId, arena: &mut IrArena<O>, fmt: &O) {
-        if let Some(trf) = self.find_term_rendered_first() {
+        if let Some(trf) = IR::find_term_rendered_first(root, arena) {
             fmt.apply_text_case(
                 trf,
                 &IngestOptions {
@@ -101,7 +101,7 @@ impl<O: OutputFormat> IR<O> {
             // Replace the configuration for rest/right-hand-side with right_config.
             // This is because we want to move all of the rest node's children to the right hand
             // side, so the node is the thing that has to move.
-            *arena.get(right)?.get_mut() = right_content;
+            *arena.get(right)?.get_mut() = right_config;
             top_seq.0 = IR::Seq(IrSeq {
                 display: None,
                 affixes: None,
@@ -763,16 +763,40 @@ impl<'a> ReducedNameToken<'a, T> {
 }
 
 impl<O: OutputFormat> IR<O> {
-    fn unwrap_name_ir(&self) -> &mut NameIR<O> {
+    pub(crate) fn unwrap_name_ir(&self) -> &NameIR<O> {
         match self {
             IR::Name(nir) => nir,
             _ => panic!("Called unwrap_name_ir on a {:?}", self),
         }
     }
-    fn unwrap_name_ir_mut(&mut self) -> &mut NameIR<O> {
+    pub(crate) fn unwrap_name_ir_mut(&mut self) -> &mut NameIR<O> {
         match self {
             IR::Name(nir) => nir,
             _ => panic!("Called unwrap_name_ir_mut on a {:?}", self),
+        }
+    }
+    pub(crate) fn unwrap_year_suffix(&self) -> &YearSuffix {
+        match self {
+            IR::YearSuffix(ys) => ys,
+            _ => panic!("Called unwrap_year_suffix on a {:?}", self),
+        }
+    }
+    pub(crate) fn unwrap_year_suffix_mut(&mut self) -> &mut YearSuffix {
+        match self {
+            IR::YearSuffix(ys) => ys,
+            _ => panic!("Called unwrap_year_suffix_mut on a {:?}", self),
+        }
+    }
+    pub(crate) fn unwrap_cond_disamb(&self) -> &ConditionalDisambIR {
+        match self {
+            IR::ConditionalDisamb(cond) => cond,
+            _ => panic!("Called unwrap_cond_disamb on a {:?}", self),
+        }
+    }
+    pub(crate) fn unwrap_cond_disamb_mut(&mut self) -> &mut ConditionalDisambIR {
+        match self {
+            IR::ConditionalDisamb(cond) => cond,
+            _ => panic!("Called unwrap_cond_disamb_mut on a {:?}", self),
         }
     }
 }

--- a/crates/proc/src/ir/transforms.rs
+++ b/crates/proc/src/ir/transforms.rs
@@ -873,10 +873,9 @@ pub fn subsequent_author_substitute<O: OutputFormat>(
                         replace_single_child(current_id, node, arena);
                     }
                 } else if sas.is_empty() {
-                    *current_ir = IR::Rendered(None);
+                    let empty_node = arena.new_node((IR::Rendered(None), GroupVars::Important));
+                    replace_single_child(current_id, empty_node, arena);
                 } else {
-                    *current_ir = IR::Seq(IrSeq::default());
-
                     // Remove all children
                     let children: Vec<_> = current_id.children(arena).collect();
                     children.into_iter().for_each(|ch| ch.remove_subtree(arena));

--- a/crates/proc/src/ir/transforms.rs
+++ b/crates/proc/src/ir/transforms.rs
@@ -449,7 +449,7 @@ pub struct Unnamed3<O: OutputFormat> {
 
 use std::fmt::{Debug, Formatter};
 
-impl Debug for Unnamed3<Markup> {
+impl<O: OutputFormat<Output = String>> Debug for Unnamed3<O> {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         let fmt = &Markup::default();
         f.debug_struct("Unnamed3")
@@ -468,7 +468,7 @@ impl Debug for Unnamed3<Markup> {
             .field("collapsed_year_suffixes", &self.collapsed_year_suffixes)
             .field("collapsed_ranges", &self.collapsed_ranges)
             .field("vanished", &self.vanished)
-            .field("gen4_full", &self.gen4.arena)
+            .field("gen4_full", &self.gen4)
             .finish()
     }
 }
@@ -493,6 +493,7 @@ impl<O: OutputFormat> Unnamed3<O> {
     }
 }
 
+// pub fn group_and_collapse<O: OutputFormat<Output = String>>(
 pub fn group_and_collapse<O: OutputFormat<Output = String>>(
     db: &dyn IrDatabase,
     fmt: &Markup,
@@ -636,7 +637,7 @@ pub fn group_and_collapse<O: OutputFormat<Output = String>>(
                         if u.is_first {
                             let following = rest.iter_mut().take_while(|u| u.should_collapse);
                             let mut count = 0;
-                            for (nix, cite) in following.enumerate() {
+                            for cite in following {
                                 let gen4 = Arc::make_mut(&mut cite.gen4);
                                 IR::suppress_names(gen4.root, &mut gen4.arena);
                                 count += 1;
@@ -654,7 +655,7 @@ pub fn group_and_collapse<O: OutputFormat<Output = String>>(
                     if let Some((u, rest)) = slice.split_first_mut() {
                         if u.is_first {
                             let following = rest.iter_mut().take_while(|u| u.should_collapse);
-                            for (nix, cite) in following.enumerate() {
+                            for cite in following {
                                 let gen4 = Arc::make_mut(&mut cite.gen4);
                                 IR::suppress_names(gen4.root, &mut gen4.arena)
                             }
@@ -708,7 +709,6 @@ pub fn group_and_collapse<O: OutputFormat<Output = String>>(
                     ix += 1;
                 }
             }
-            _ => {}
         }
     }
 }

--- a/crates/proc/src/ir/transforms.rs
+++ b/crates/proc/src/ir/transforms.rs
@@ -175,8 +175,8 @@ impl<O: OutputFormat> IR<O> {
     }
 
     pub fn find_year_suffix(node: NodeId, arena: &IrArena<O>) -> Option<u32> {
-        IR::has_implicit_year_suffix(node, arena)
-            .or_else(|| IR::has_explicit_year_suffix(node, arena))
+        IR::has_explicit_year_suffix(node, arena)
+            .or_else(|| IR::has_implicit_year_suffix(node, arena))
     }
 
     fn find_first_year_and_suffix(node: NodeId, arena: &IrArena<O>) -> Option<(NodeId, u32)> {
@@ -252,7 +252,7 @@ impl<O: OutputFormat> IR<O> {
                 hook: YearSuffixHook::Plain,
                 suffix_num: Some(n),
                 ..
-            }) if IR::is_empty(node, arena) => Some(n),
+            }) if !IR::is_empty(node, arena) => Some(n),
 
             IR::ConditionalDisamb(_) | IR::Seq(_) => {
                 // assumes it's the first one that appears

--- a/crates/proc/src/lib.rs
+++ b/crates/proc/src/lib.rs
@@ -285,7 +285,7 @@ impl IrState {
     pub fn maybe_suppress_date<T: Default>(
         &mut self,
         var: DateVariable,
-        f: impl Fn(&mut Self) -> T,
+        mut f: impl FnMut(&mut Self) -> T,
     ) -> T {
         if self.is_suppressed_date(var) {
             Default::default()

--- a/crates/proc/src/lib.rs
+++ b/crates/proc/src/lib.rs
@@ -25,10 +25,10 @@ mod element;
 mod group;
 mod helpers;
 mod ir;
-mod ref_ir;
 mod names;
 mod number;
 mod page_range;
+mod ref_ir;
 mod renderer;
 mod sort;
 mod unicode;
@@ -39,7 +39,7 @@ pub use crate::db::built_cluster_before_output;
 pub(crate) mod prelude {
     pub use crate::ir::IrSum;
     pub type IrArena<O = Markup> = indextree::Arena<IrSum<O>>;
-    pub use indextree::{NodeId, Node};
+    pub use indextree::{Node, NodeId};
     #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
     pub enum CiteOrBib {
         Citation,
@@ -51,8 +51,8 @@ pub(crate) mod prelude {
     pub use citeproc_db::{CiteDatabase, CiteId, LocaleDatabase, StyleDatabase};
     pub use citeproc_io::output::markup::Markup;
     pub use citeproc_io::output::OutputFormat;
-    pub use citeproc_io::{NumberLike, NumericValue};
     pub use citeproc_io::IngestOptions;
+    pub use citeproc_io::{NumberLike, NumericValue};
 
     pub use csl::{Affixes, DisplayMode, Element, Formatting, TextCase};
 
@@ -282,7 +282,11 @@ impl IrState {
     }
 
     #[inline]
-    pub fn maybe_suppress_date<T: Default>(&mut self, var: DateVariable, f: impl Fn(&mut Self) -> T) -> T {
+    pub fn maybe_suppress_date<T: Default>(
+        &mut self,
+        var: DateVariable,
+        f: impl Fn(&mut Self) -> T,
+    ) -> T {
         if self.is_suppressed_date(var) {
             Default::default()
         } else {

--- a/crates/proc/src/lib.rs
+++ b/crates/proc/src/lib.rs
@@ -25,6 +25,7 @@ mod element;
 mod group;
 mod helpers;
 mod ir;
+mod ref_ir;
 mod names;
 mod number;
 mod page_range;
@@ -55,6 +56,7 @@ pub(crate) mod prelude {
     pub use crate::cite_context::CiteContext;
     pub use crate::group::GroupVars;
     pub use crate::ir::*;
+    pub use crate::ref_ir::*;
 
     pub(crate) use crate::disamb::{Disambiguation, Edge, EdgeData, RefContext};
     pub(crate) use crate::helpers::*;

--- a/crates/proc/src/lib.rs
+++ b/crates/proc/src/lib.rs
@@ -37,6 +37,9 @@ mod walker;
 pub use crate::db::built_cluster_before_output;
 
 pub(crate) mod prelude {
+    pub use crate::ir::IrSum;
+    pub type IrArena<O = Markup> = indextree::Arena<IrSum<O>>;
+    pub use indextree::{NodeId, Node};
     #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
     pub enum CiteOrBib {
         Citation,
@@ -90,7 +93,8 @@ where
         db: &dyn IrDatabase,
         state: &mut IrState,
         ctx: &CiteContext<'c, O, I>,
-    ) -> IrSum<O>;
+        arena: &mut IrArena<O>,
+    ) -> NodeId;
 }
 
 use csl::{Affixes, Delimiter, DisplayMode, Formatting, Name, NameEtAl, NameLabelInput, Names};

--- a/crates/proc/src/names.rs
+++ b/crates/proc/src/names.rs
@@ -370,7 +370,8 @@ pub fn intermediate<'c, O: OutputFormat, I: OutputFormat>(
         },
         ..Default::default()
     };
-    arena.new_node((IR::Seq(seq), GroupVars::Important))
+    *arena.get_mut(seq_node).unwrap().get_mut() = (IR::Seq(seq), GroupVars::Important);
+    seq_node
 }
 
 impl<'c, O, I> Proc<'c, O, I> for Names

--- a/crates/proc/src/names.rs
+++ b/crates/proc/src/names.rs
@@ -298,7 +298,13 @@ pub fn intermediate<'c, O: OutputFormat, I: OutputFormat>(
                 ctx.disamb_pass,
                 None,
             ) {
-                let names_seq = NameIR::rendered_ntbs_to_node(result, arena, is_sort_key, label_after_name, built_label.as_ref());
+                let names_seq = NameIR::rendered_ntbs_to_node(
+                    result,
+                    arena,
+                    is_sort_key,
+                    label_after_name,
+                    built_label.as_ref(),
+                );
                 let nir_node = arena.new_node((IR::Name(nir), GroupVars::Important));
                 nir_node.append(names_seq, arena);
                 nir_node

--- a/crates/proc/src/number.rs
+++ b/crates/proc/src/number.rs
@@ -1,8 +1,8 @@
 use citeproc_io::NumericToken::{self, *};
 use citeproc_io::NumericValue;
 use csl::{
-    Gender, Locale, MiscTerm, OrdinalTerm, OrdinalTermSelector, PageRangeFormat,
-    SimpleTermSelector, TermFormExtended, NumberVariable,
+    Gender, Locale, MiscTerm, NumberVariable, OrdinalTerm, OrdinalTermSelector, PageRangeFormat,
+    SimpleTermSelector, TermFormExtended,
 };
 use std::fmt::Write;
 
@@ -63,7 +63,8 @@ pub fn get_hyphen(locale: &Locale, variable: NumberVariable) -> &str {
     // https://github.com/Juris-M/citeproc-js/blob/1aa49dd2ab9a1c85d3060073780d65c86754a438/src/util_number.js#L584
     let get = |term: MiscTerm| {
         let sel = SimpleTermSelector::Misc(term, TermFormExtended::Symbol);
-        locale.get_simple_term(sel)
+        locale
+            .get_simple_term(sel)
             .map(|amp| amp.singular().trim())
             .unwrap_or("\u{2013}")
     };
@@ -172,7 +173,12 @@ pub fn roman_representable(val: &NumericValue) -> bool {
     }
 }
 
-pub fn roman_lower(ts: &[NumericToken], locale: &Locale, variable: NumberVariable, prf: Option<PageRangeFormat>) -> String {
+pub fn roman_lower(
+    ts: &[NumericToken],
+    locale: &Locale,
+    variable: NumberVariable,
+    prf: Option<PageRangeFormat>,
+) -> String {
     let mut s = String::with_capacity(ts.len() * 2); // estimate
     use std::convert::TryInto;
     for t in ts {

--- a/crates/proc/src/page_range.rs
+++ b/crates/proc/src/page_range.rs
@@ -15,22 +15,16 @@ pub fn truncate_prf(prf: PageRangeFormat, first: u32, mut second: u32) -> u32 {
                 let chopped = truncate_diff(first, second, 2);
                 if closest_smaller_power_of_10(chopped) == 100 {
                     // force 4 digits if 3 are different
-                    return truncate_diff(first, second, 4)
+                    return truncate_diff(first, second, 4);
                 }
                 chopped
             } else {
                 truncate_diff(first, second, 2)
             }
         }
-        PageRangeFormat::Minimal => {
-            truncate_diff(first, second, 1)
-        }
-        PageRangeFormat::MinimalTwo => {
-            truncate_diff(first, second, 2)
-        }
-        PageRangeFormat::Expanded => {
-            second
-        }
+        PageRangeFormat::Minimal => truncate_diff(first, second, 1),
+        PageRangeFormat::MinimalTwo => truncate_diff(first, second, 2),
+        PageRangeFormat::Expanded => second,
     }
 }
 
@@ -165,5 +159,3 @@ impl DigitsBase10 {
         DigitsBase10 { mask, num }
     }
 }
-
-

--- a/crates/proc/src/ref_ir.rs
+++ b/crates/proc/src/ref_ir.rs
@@ -1,0 +1,176 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright © 2020 Corporation for Digital Scholarship
+
+use crate::prelude::*;
+use crate::disamb::Nfa;
+use csl::Atom;
+use crate::disamb::names::RefNameIR;
+use citeproc_io::output::LocalizedQuotes;
+use csl::{Affixes, Formatting};
+
+#[allow(dead_code)]
+#[derive(Clone, Debug)]
+pub enum RefIR {
+    /// A piece of output that a cite can match in the final DFA.
+    /// e.g.
+    ///
+    /// ```txt
+    /// EdgeData::Output(r#"<span style="font-weight: bold;">"#)
+    /// EdgeData::Output("Some title, <i>23/4/1969</i>")
+    /// EdgeData::Locator
+    /// ```
+    ///
+    /// Each is interned into an `Edge` newtype referencing the salsa database.
+    Edge(Option<Edge>),
+
+    /// When constructing RefIR, we know whether the names variables exist or not.
+    /// So we don't have to handle 'substitute' any special way -- just drill down into the
+    /// names element, apply its formatting, and end up with
+    ///
+    /// ```txt
+    /// [
+    ///     Edge("<whatever formatting>"),
+    ///     // whatever the substitute element outputted
+    ///     Edge("</whatever>")
+    /// ]
+    /// ```
+    ///
+    /// The Nfa represents all the edge streams that a Names block can output for one of its
+    /// variables.
+    Name(RefNameIR, Nfa),
+
+    /// A non-string EdgeData can be surrounded by a Seq with other strings to apply its
+    /// formatting. This will use `OutputFormat::stack_preorder() / ::stack_postorder()`.
+    ///
+    /// ```txt
+    /// RefIR::Seq(vec![
+    ///     EdgeData::Output("<i>"),
+    ///     EdgeData::Locator,
+    ///     EdgeData::Output("</i>"),
+    /// ])
+    /// ```
+    Seq(RefIrSeq),
+    // Could use this to apply a FreeCond set to a reference to create a path through the
+    // constructed NFA.
+    // See the module level documentation for `disamb`.
+    // Branch(Arc<Conditions>, Box<IR<O>>),
+}
+
+impl Eq for RefIR {}
+impl PartialEq for RefIR {
+    fn eq(&self, _other: &Self) -> bool {
+        false
+    }
+}
+impl Default for RefIR {
+    fn default() -> Self {
+        RefIR::Edge(None)
+    }
+}
+
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
+pub struct RefIrSeq {
+    pub contents: Vec<RefIR>,
+    pub formatting: Option<Formatting>,
+    pub affixes: Option<Affixes>,
+    pub delimiter: Atom,
+    pub quotes: Option<LocalizedQuotes>,
+    pub text_case: TextCase,
+}
+
+impl RefIR {
+    pub fn debug(&self, db: &dyn IrDatabase) -> String {
+        match self {
+            RefIR::Edge(Some(e)) => format!("{:?}", db.lookup_edge(*e)),
+            RefIR::Edge(None) => "None".into(),
+            RefIR::Seq(seq) => {
+                let mut s = String::new();
+                s.push_str("[");
+                let mut seen = false;
+                for x in &seq.contents {
+                    if seen {
+                        s.push_str(",");
+                    }
+                    seen = true;
+                    s.push_str(&x.debug(db));
+                }
+                s.push_str("]");
+                s
+            }
+            RefIR::Name(rnir, _nfa) => format!("NameVariable::{:?}", rnir.variable),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        match self {
+            RefIR::Edge(None) => true,
+            RefIR::Seq(seq) => seq.contents.is_empty(),
+            RefIR::Name(_rnir, nfa) => nfa.is_empty(),
+            _ => false,
+        }
+    }
+
+    pub(crate) fn keep_first_ysh(&mut self, ysh_explicit_edge: Edge, ysh_plain_edge: Edge, ysh_edge: Edge) {
+        let found = &mut false;
+        self.visit_ysh(ysh_explicit_edge, &mut |opt_e| {
+            if !*found {
+                // first time
+                *found = true;
+                *opt_e = Some(ysh_edge);
+            } else {
+                // subsequent ones are extraneous, so make them disappear
+                *opt_e = None;
+            }
+            false
+        });
+        self.visit_ysh(ysh_plain_edge, &mut |opt_e| {
+            if !*found {
+                *found = true;
+                *opt_e = Some(ysh_edge);
+            } else {
+                *opt_e = None;
+            }
+            false
+        });
+    }
+
+    pub(crate) fn visit_ysh<F>(&mut self, ysh_edge: Edge, callback: &mut F) -> bool
+    where
+        F: (FnMut(&mut Option<Edge>) -> bool),
+    {
+        match self {
+            RefIR::Edge(ref mut opt_e) if *opt_e == Some(ysh_edge) => callback(opt_e),
+            RefIR::Seq(seq) => {
+                for ir in seq.contents.iter_mut() {
+                    let done = ir.visit_ysh(ysh_edge, callback);
+                    if done {
+                        return true;
+                    }
+                }
+                false
+            }
+            _ => false,
+        }
+    }
+}
+
+// #[derive(Debug, Clone)]
+// pub struct RefIrNameCounter {
+//     name_irs: Vec<RefNameIR>,
+// }
+// impl RefIrNameCounter {
+//     fn count(&self) -> u32 {
+//         500
+//     }
+//     pub fn render_ref(&self, db: &dyn IrDatabase, ctx: &RefContext<'_, Markup>, stack: Formatting, piq: Option<bool>) -> (RefIR, GroupVars) {
+//         let count = self.count();
+//         let fmt = ctx.format;
+//         let out = fmt.output_in_context(fmt.text_node(format!("{}", count), None), stack, piq);
+//         let edge = db.edge(EdgeData::<Markup>::Output(out));
+//         (RefIR::Edge(Some(edge)), GroupVars::Important)
+//     }
+// }
+

--- a/crates/proc/src/ref_ir.rs
+++ b/crates/proc/src/ref_ir.rs
@@ -4,11 +4,11 @@
 //
 // Copyright © 2020 Corporation for Digital Scholarship
 
-use crate::prelude::*;
-use crate::disamb::Nfa;
-use csl::Atom;
 use crate::disamb::names::RefNameIR;
+use crate::disamb::Nfa;
+use crate::prelude::*;
 use citeproc_io::output::LocalizedQuotes;
+use csl::Atom;
 use csl::{Affixes, Formatting};
 
 #[allow(dead_code)]
@@ -113,7 +113,12 @@ impl RefIR {
         }
     }
 
-    pub(crate) fn keep_first_ysh(&mut self, ysh_explicit_edge: Edge, ysh_plain_edge: Edge, ysh_edge: Edge) {
+    pub(crate) fn keep_first_ysh(
+        &mut self,
+        ysh_explicit_edge: Edge,
+        ysh_plain_edge: Edge,
+        ysh_edge: Edge,
+    ) {
         let found = &mut false;
         self.visit_ysh(ysh_explicit_edge, &mut |opt_e| {
             if !*found {
@@ -173,4 +178,3 @@ impl RefIR {
 //         (RefIR::Edge(Some(edge)), GroupVars::Important)
 //     }
 // }
-

--- a/crates/proc/src/renderer.rs
+++ b/crates/proc/src/renderer.rs
@@ -374,15 +374,15 @@ impl<'c, O: OutputFormat, I: OutputFormat> Renderer<'c, O, I> {
             .get_text_term(term_selector, plural)
             .filter(|x| !x.is_empty())
             .map(|val| {
-            let options = IngestOptions {
-                text_case: text.text_case,
-                quotes: self.quotes(),
-                strip_periods: text.strip_periods,
-                is_english: self.ctx.is_english(),
-                ..Default::default()
-            };
-            self.render_text_el(val, text, &options, None)
-        })
+                let options = IngestOptions {
+                    text_case: text.text_case,
+                    quotes: self.quotes(),
+                    strip_periods: text.strip_periods,
+                    is_english: self.ctx.is_english(),
+                    ..Default::default()
+                };
+                self.render_text_el(val, text, &options, None)
+            })
     }
 
     fn render_text_el(
@@ -403,7 +403,12 @@ impl<'c, O: OutputFormat, I: OutputFormat> Renderer<'c, O, I> {
         fmt.with_display(b, text.display, self.ctx.in_bibliography())
     }
 
-    pub fn name_label(&self, label: &NameLabel, var: NameVariable, label_var: NameVariable) -> Option<O::Build> {
+    pub fn name_label(
+        &self,
+        label: &NameLabel,
+        var: NameVariable,
+        label_var: NameVariable,
+    ) -> Option<O::Build> {
         let NameLabel {
             form,
             formatting,

--- a/crates/proc/src/sort.rs
+++ b/crates/proc/src/sort.rs
@@ -83,7 +83,7 @@ pub fn sorted_refs(db: &dyn IrDatabase) -> Arc<(Vec<Atom>, FnvHashMap<Atom, u32>
     // Construct preordered, which will then be stably sorted. It contains:
     // - All refs from all cites, in the order they appear (excluding non-existent)
     // - Then, all of the uncited reference ids.
-    // 
+    //
     // first, compute refs in the order that they are cited.
     // stable sorting will cause this to be the final tiebreaker.
     let all = db.all_keys();
@@ -475,9 +475,7 @@ impl<'a, O: OutputFormat> StyleWalker for SortingWalker<'a, O> {
         }
         let out = output.unwrap_or_default();
         match fold_type {
-            WalkerFoldType::Group(g) => {
-                gv_acc.implicit_conditional(out)
-            }
+            WalkerFoldType::Group(g) => gv_acc.implicit_conditional(out),
             _ => (out, gv_acc),
         }
     }
@@ -575,8 +573,12 @@ impl<'a, O: OutputFormat> StyleWalker for SortingWalker<'a, O> {
 
     fn names(&mut self, names: &Names) -> Self::Output {
         let mut arena = IrArena::new();
-        let node = crate::names::intermediate(names, self.db, &mut self.state, &self.ctx, &mut arena);
-        (IR::flatten(id, &arena, &self.ctx.format).unwrap_or_default(), gv)
+        let node =
+            crate::names::intermediate(names, self.db, &mut self.state, &self.ctx, &mut arena);
+        (
+            IR::flatten(id, &arena, &self.ctx.format).unwrap_or_default(),
+            gv,
+        )
     }
 
     // The spec is not functional. Specificlly, negative/BCE years won't work. So the year must be
@@ -585,7 +587,10 @@ impl<'a, O: OutputFormat> StyleWalker for SortingWalker<'a, O> {
     fn date(&mut self, date: &BodyDate) -> Self::Output {
         let mut arena = IrArena::new();
         let node = date.intermediate(self.db, &mut self.state, &self.ctx, &mut arena);
-        (IR::flatten(id, &arena, &self.ctx.format).unwrap_or_default(), gv)
+        (
+            IR::flatten(id, &arena, &self.ctx.format).unwrap_or_default(),
+            gv,
+        )
     }
 
     fn text_macro(&mut self, text: &TextElement, name: &Atom) -> Self::Output {

--- a/crates/proc/src/sort.rs
+++ b/crates/proc/src/sort.rs
@@ -453,7 +453,7 @@ impl<'a, O: OutputFormat> StyleWalker for SortingWalker<'a, O> {
     type Output = (String, GroupVars);
     type Checker = CiteContext<'a, PlainText, O>;
 
-    fn default(&self) -> Self::Output {
+    fn default(&mut self) -> Self::Output {
         Default::default()
     }
     fn get_checker(&self) -> Option<&Self::Checker> {

--- a/crates/proc/src/walker.rs
+++ b/crates/proc/src/walker.rs
@@ -19,7 +19,7 @@ pub enum WalkerFoldType<'a> {
 pub trait StyleWalker {
     type Output;
     type Checker: CondChecker;
-    fn default(&self) -> Self::Output;
+    fn default(&mut self) -> Self::Output;
     fn fold(&mut self, elements: &[Element], _fold_type: WalkerFoldType) -> Self::Output {
         for el in elements {
             let _ = self.element(el);

--- a/crates/proc/src/walker.rs
+++ b/crates/proc/src/walker.rs
@@ -17,13 +17,14 @@ pub enum WalkerFoldType<'a> {
 }
 
 pub trait StyleWalker {
-    type Output: Default;
+    type Output;
     type Checker: CondChecker;
+    fn default(&self) -> Self::Output;
     fn fold(&mut self, elements: &[Element], _fold_type: WalkerFoldType) -> Self::Output {
         for el in elements {
             let _ = self.element(el);
         }
-        Self::Output::default()
+        self.default()
     }
     /// Default returns None, but if you implement & return Some, you get condition checking for
     /// free
@@ -73,13 +74,13 @@ pub trait StyleWalker {
         _svar: StandardVariable,
         _form: VariableForm,
     ) -> Self::Output {
-        Self::Output::default()
+        self.default()
     }
     fn text_value(&mut self, _text: &TextElement, _value: &Atom) -> Self::Output {
-        Self::Output::default()
+        self.default()
     }
     fn text_macro(&mut self, _source: &TextElement, _name: &Atom) -> Self::Output {
-        Self::Output::default()
+        self.default()
     }
     fn text_term(
         &mut self,
@@ -87,19 +88,19 @@ pub trait StyleWalker {
         _sel: TextTermSelector,
         _plural: bool,
     ) -> Self::Output {
-        Self::Output::default()
+        self.default()
     }
     fn label(&mut self, _label: &LabelElement) -> Self::Output {
-        Self::Output::default()
+        self.default()
     }
     fn number(&mut self, _source: &NumberElement) -> Self::Output {
-        Self::Output::default()
+        self.default()
     }
     fn names(&mut self, _name: &Names) -> Self::Output {
-        Self::Output::default()
+        self.default()
     }
     fn date(&mut self, _date: &BodyDate) -> Self::Output {
-        Self::Output::default()
+        self.default()
     }
     fn group(&mut self, group: &Group) -> Self::Output {
         self.fold(&group.elements, WalkerFoldType::Group(group))

--- a/crates/test-utils/src/humans.rs
+++ b/crates/test-utils/src/humans.rs
@@ -8,7 +8,8 @@ use super::{Format, Mode, TestCase};
 
 use citeproc::prelude::*;
 use citeproc_io::{
-    Cite, Cluster, ClusterId, ClusterNumber, IntraNote, Locators, Reference, Suppression, ClusterPosition,
+    Cite, Cluster, ClusterId, ClusterNumber, ClusterPosition, IntraNote, Locators, Reference,
+    Suppression,
 };
 
 use lazy_static::lazy_static;
@@ -39,7 +40,10 @@ impl CitationItem {
             CitationItem::Map { cites } => cites,
         };
         let cites = v.iter().map(CiteprocJsCite::to_cite).collect();
-        Cluster { id: index + 1, cites }
+        Cluster {
+            id: index + 1,
+            cites,
+        }
     }
 }
 
@@ -303,7 +307,11 @@ impl JsExecutor<'_> {
     fn to_renumbering(&mut self, renum: &mut Vec<ClusterPosition>, prepost: &[PrePost]) {
         for &PrePost(ref string, note_number) in prepost.iter() {
             let id = self.get_id(&string);
-            let note = if note_number == 0 { None } else { Some(note_number) };
+            let note = if note_number == 0 {
+                None
+            } else {
+                Some(note_number)
+            };
             renum.push(ClusterPosition { id, note })
         }
     }

--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -260,7 +260,7 @@ impl Warmup {
         Warmup {
             default_locale: true,
             _other_locales: vec![],
-            ref_dfa: true
+            ref_dfa: true,
         }
     }
     pub fn execute(&self, proc: &mut Processor) {
@@ -271,7 +271,9 @@ impl Warmup {
             // Precompute dfas
             // We don't know what 'cited_keys()' is yet, so just do all of them
             for k in proc.all_keys().iter() {
-                let _dfa = proc.ref_dfa(k.clone()).expect("cited_keys should all exist");
+                let _dfa = proc
+                    .ref_dfa(k.clone())
+                    .expect("cited_keys should all exist");
             }
         }
     }
@@ -285,7 +287,8 @@ macro_rules! regex {
 }
 
 pub fn normalise_html(strg: &str) -> String {
-    let rep = strg.replace("&#x2f;", "/")
+    let rep = strg
+        .replace("&#x2f;", "/")
         .replace("&#x27;", "'")
         .replace("&#60;", "&lt;")
         .replace("&#62;", "&gt;")

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -215,8 +215,11 @@ impl Driver {
         let cites: Vec<Cite<Markup>> = utils::read_js_array(cites)?;
         let positions: Vec<ClusterPosition> = utils::read_js_array(positions)?;
         let mut eng = self.engine.borrow_mut();
-        let preview =
-            eng.preview_citation_cluster(cites, PreviewPosition::MarkWithZero(&positions), SupportedFormat::from_str(format).ok());
+        let preview = eng.preview_citation_cluster(
+            cites,
+            PreviewPosition::MarkWithZero(&positions),
+            SupportedFormat::from_str(format).ok(),
+        );
         preview
             .map_err(|e| JsError::new(&e.to_string()))
             .and_then(|b| JsValue::from_serde(&b).map_err(|e| JsError::new(&e.to_string())))


### PR DESCRIPTION
There was a persistent problem with the way IR modifications were being done. The IR has to be `Send + Sync`, as it eventually goes in an Arc and has to be thread safe for Salsa. The mutable portions have until now been stored as an `Arc<Mutex<T>>` -- little mutable NameIR structs that can be modified as disambiguation progresses. This caused errors where:

- salsa needed to check equality of IR, requiring unlocking the mutex but the two IRs were identical, and so Arc::ptr_eq needed to be used to make sure there was no recursive unlocking. And not to be cloning the Arc instead of the Mutex, requiring a Clone implementation...
- there was a bug where calling some query from inside a locked mutex would eventually drive salsa to unlock the same mutex, hence recursion again. FYI, `std::sync::Mutex` is not recursive and the program would crash.

This was not good. So instead, each IR is a flat [`indextree::Arena`](https::docs.rs/indextree) array, with indices pointing to nodes in the graph and maintaining their own parent/child pointers. A `&mut arena` is carried around `citeproc_proc` to install nodes into. Benefits:

- No more mutexes! A source of bugs squashed.
- Tree APIs with very little performance hit (and possible optimisations remain). It's ~4% slower. I did some casual benchmarking of indextree alternatives and found it to be definitely the fastest.
- Easier debug printing of the entire structure, as it's homogenous rather than requiring digging into enum shapes.
- You can collect all the NameIR/conditional/year-suffix nodes as indices, and then get mutable references as you require them.