### PR TITLE
Throw proper JS errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,9 +20,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.25"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9267dff192e68f3399525901e709a48c1d3982c9c072fa32f2127a0cb0babf14"
+checksum = "6b602bfe940d21c130f3895acd65221e8a61270debe89d628b9cb4e3ccb8569b"
 
 [[package]]
 name = "arrayref"
@@ -505,6 +505,7 @@ dependencies = [
  "string_cache",
  "strum",
  "strum_macros",
+ "thiserror",
 ]
 
 [[package]]
@@ -1612,9 +1613,9 @@ checksum = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
 
 [[package]]
 name = "roxmltree"
-version = "0.7.3"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0852407257c1b696a0c66b9db3ffe7769c2744a2fa725c8050e6f3e5a823c02b"
+checksum = "17dfc6c39f846bfc7d2ec442ad12055d79608d501380789b965d22f9354451f2"
 dependencies = [
  "xmlparser",
 ]
@@ -1977,18 +1978,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.9"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f357d1814b33bc2dc221243f8424104bfe72dbe911d5b71b3816a2dff1c977e"
+checksum = "7dfdd070ccd8ccb78f4ad66bf1982dc37f620ef696c6b5028fe2ed83dd3d0d08"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.9"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb2e25d25307eb8436894f727aba8f65d07adf02e5b35a13cebed48bd282bfef"
+checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2280,6 +2281,7 @@ checksum = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
 name = "wasm"
 version = "0.0.1"
 dependencies = [
+ "anyhow",
  "cfg-if",
  "citeproc",
  "citeproc-io",
@@ -2448,9 +2450,9 @@ checksum = "3a74a847d8392999f89e9668c4dd46283b91fd6fc1f34aa5ecf4ceaf8fa3258e"
 
 [[package]]
 name = "xmlparser"
-version = "0.10.0"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8110496c5bcc0d966b0b2da38d5a791aa139eeb0b80e7840a7463c2b806921eb"
+checksum = "114ba2b24d2167ef6d67d7d04c8cc86522b87f490025f39f0303b7db5bf5e3d8"
 
 [[package]]
 name = "yaml-rust"

--- a/crates/csl/Cargo.toml
+++ b/crates/csl/Cargo.toml
@@ -15,7 +15,7 @@ readme = "README.md"
 repository = "https://github.com/cormacrelf/citeproc-rs"
 
 [dependencies]
-roxmltree = "0.7.0"
+roxmltree = "0.13.0"
 fnv = "1.0.6"
 strum = "0.15.0"
 strum_macros = "0.19"
@@ -26,3 +26,4 @@ serde_derive = "1.0.100"
 string_cache = "0.7.3"
 semver = "0.9.0"
 log = "0.4.8"
+thiserror = "1.0.20"

--- a/crates/csl/src/attr.rs
+++ b/crates/csl/src/attr.rs
@@ -132,7 +132,7 @@ pub(crate) fn attribute_var_type<T: GetAttribute>(
 
 pub(crate) fn attribute_option<'a, 'd: 'a, T: GetAttribute>(
     node: &Node<'a, 'd>,
-    attr: impl Into<ExpandedName<'a>> + Clone,
+    attr: impl Into<ExpandedName<'a, 'd>> + Clone,
     info: &ParseInfo,
 ) -> Result<Option<T>, InvalidCsl> {
     match node.attribute(attr.clone()) {

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -14,6 +14,20 @@ edition = "2018"
 repository = "https://github.com/cormacrelf/citeproc-rs"
 description = "citeproc-rs, compiled to WebAssembly"
 
+# TODO: Set the opt level on new wasm-pack 0.6.0 config
+# when it's released, so as not to interfere with the
+# other native binary targets (cargo only lets you set it
+# on the workspace root)
+
+# [profile.release]
+# # Tell `rustc` to optimize for small code size.
+# opt-level = "s"
+# lto = true
+
+# https://github.com/rustwasm/wasm-pack/issues/886#issuecomment-667669802
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ["-O3", "--enable-mutable-globals"]
+
 [lib]
 crate-type = ["cdylib", "rlib"]
 
@@ -43,6 +57,7 @@ js-sys = "0.3.44"
 serde = "1.0.100"
 serde_derive = "1.0.100"
 serde_json = "1.0.40"
+anyhow = "1.0.32"
 
 [dependencies.wasm-bindgen]
 version = "0.2.67"
@@ -56,18 +71,4 @@ features = ["release_max_level_error"]
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.17"
-
-# TODO: Set the opt level on new wasm-pack 0.6.0 config
-# when it's released, so as not to interfere with the
-# other native binary targets (cargo only lets you set it
-# on the workspace root)
-
-# [profile.release]
-# # Tell `rustc` to optimize for small code size.
-# opt-level = "s"
-# lto = true
-
-# https://github.com/rustwasm/wasm-pack/issues/886#issuecomment-667669802
-[package.metadata.wasm-pack.profile.release]
-wasm-opt = ["-O3", "--enable-mutable-globals"]
 


### PR DESCRIPTION
Fixes #25.

Upgrades roxmltree while we're at it. Minor API change to setStyle(); it now throws rather than returning a perfectly serialized JSON error object. 