### PR TITLE
Queue-draining fullRender() API; better diffing & bibliography docs

### DIFF
--- a/crates/citeproc/src/api.rs
+++ b/crates/citeproc/src/api.rs
@@ -9,7 +9,6 @@
 use super::Processor;
 use citeproc_io::output::{markup::Markup, OutputFormat};
 use citeproc_io::ClusterId;
-use citeproc_proc::db::IrDatabase;
 use std::str::FromStr;
 use std::sync::Arc;
 

--- a/crates/citeproc/src/api.rs
+++ b/crates/citeproc/src/api.rs
@@ -102,6 +102,20 @@ impl UpdateSummary {
     }
 }
 
+#[derive(Serialize, Default, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct BibEntry<O: OutputFormat = Markup> {
+    pub id: Atom,
+    pub value: Arc<O::Output>,
+}
+
+#[derive(Serialize, Default, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct FullRender {
+    pub all_clusters: FnvHashMap<ClusterId, Arc<String>>,
+    pub bib_entries: Vec<BibEntry<Markup>>,
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, Ord, PartialOrd, PartialEq)]
 pub enum IncludeUncited {
     /// The default

--- a/crates/citeproc/src/lib.rs
+++ b/crates/citeproc/src/lib.rs
@@ -15,11 +15,11 @@ pub(crate) mod processor;
 #[cfg(test)]
 mod test;
 
-pub use self::api::{DocUpdate, IncludeUncited, SupportedFormat, UpdateSummary};
+pub use self::api::{DocUpdate, FullRender, IncludeUncited, SupportedFormat, UpdateSummary};
 pub use self::processor::{ErrorKind, PreviewPosition, Processor};
 
 pub mod prelude {
-    pub use crate::api::{DocUpdate, IncludeUncited, SupportedFormat, UpdateSummary};
+    pub use crate::api::{DocUpdate, FullRender, IncludeUncited, SupportedFormat, UpdateSummary};
     pub use crate::processor::{PreviewPosition, Processor};
     pub use citeproc_db::{
         CiteDatabase, CiteId, LocaleDatabase, LocaleFetchError, LocaleFetcher, StyleDatabase,

--- a/crates/citeproc/src/processor.rs
+++ b/crates/citeproc/src/processor.rs
@@ -455,11 +455,11 @@ impl Processor {
         }
         last_bibliography.bib_entries = new;
         let sorted_refs = self.sorted_refs();
-        if sorted_refs != old.sorted_refs {
+        if sorted_refs.0 != old.sorted_refs.0 {
             update.entry_ids = Some(sorted_refs.0.clone());
-            last_bibliography.sorted_refs = sorted_refs;
-            Some(update)
-        } else if update.updated_entries.is_empty() {
+        }
+        last_bibliography.sorted_refs = sorted_refs;
+        if update.updated_entries.is_empty() && update.entry_ids.is_none() {
             None
         } else {
             Some(update)

--- a/crates/citeproc/src/test.rs
+++ b/crates/citeproc/src/test.rs
@@ -222,7 +222,8 @@ mod preview {
                 note: Some(3),
             }, // Append at the end
         ];
-        let preview = db.preview_citation_cluster(cites, PreviewPosition::MarkWithZero(positions), None);
+        let preview =
+            db.preview_citation_cluster(cites, PreviewPosition::MarkWithZero(positions), None);
         assert_cluster!(preview.ok(), Some("Book one, subsequent"));
         assert_cluster!(db.get_cluster(1), Some("Book one"));
         assert_cluster!(db.get_cluster(2), Some("Book two"));
@@ -246,7 +247,8 @@ mod preview {
                 note: Some(2),
             },
         ];
-        let preview = db.preview_citation_cluster(cites, PreviewPosition::MarkWithZero(positions), None);
+        let preview =
+            db.preview_citation_cluster(cites, PreviewPosition::MarkWithZero(positions), None);
         assert_cluster!(preview.ok(), Some("Book one; Book three"));
         assert_cluster!(db.get_cluster(1), Some("Book one"));
         assert_cluster!(db.get_cluster(2), Some("Book two"));
@@ -266,7 +268,8 @@ mod preview {
                 note: Some(2),
             },
         ];
-        let preview = db.preview_citation_cluster(cites, PreviewPosition::MarkWithZero(positions), None);
+        let preview =
+            db.preview_citation_cluster(cites, PreviewPosition::MarkWithZero(positions), None);
         assert_cluster!(preview.ok(), Some("Book three"));
         assert_cluster!(db.get_cluster(1), Some("Book one"));
         assert_cluster!(db.get_cluster(2), Some("Book two"));

--- a/crates/proc/src/disamb/test.rs
+++ b/crates/proc/src/disamb/test.rs
@@ -11,8 +11,8 @@ use crate::test::MockProcessor;
 use citeproc_io::output::markup::Markup;
 use citeproc_io::{ClusterNumber, Reference};
 
-use csl::Variable;
 use csl::CslType;
+use csl::Variable;
 
 macro_rules! style_text_layout {
     ($ex:expr) => {{

--- a/crates/proc/src/test.rs
+++ b/crates/proc/src/test.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use citeproc_db::{LocaleFetcher, PredefinedLocales, StyleDatabase, CiteData};
+use citeproc_db::{CiteData, LocaleFetcher, PredefinedLocales, StyleDatabase};
 use citeproc_io::{output::markup::Markup, Cluster, Reference};
 use csl::Atom;
 

--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -200,11 +200,11 @@ fn get_bib_string(proc: &Processor) -> String {
         match fmt {
             Markup::Html(_) => {
                 string.push_str("  <div class=\"csl-entry\">");
-                string.push_str(&entry);
+                string.push_str(&entry.value);
                 string.push_str("</div>");
             }
             _ => {
-                string.push_str(&entry);
+                string.push_str(&entry.value);
             }
         }
     }

--- a/crates/wasm/README.md
+++ b/crates/wasm/README.md
@@ -307,15 +307,37 @@ diff.clusters.forEach(changedCluster => {
     let [id, html] = changedCluster;
     myDocument.updateCluster(id, html);
 });
-diff.bibliography.entryIds.forEach(citekey => {
-    let html = diff.updatedEntries[citekey];
-    myDocument.updateBibEntry(citekey, html);
-});
+
+// Null? No change to the bibliography.
+if (diff.bibliography != null) {
+    let bib = diff.bibliography;
+    // entryIds is the full list of entries in the bibliography.
+    // If a citekey isn't in there, it should be removed.
+    myDocument.removeAbsentEntryIds(bib.entryIds);
+    // Then, apply the entries that have actually changed
+    for (let key of Object.keys(bib.updatedEntries)) {
+        let rendered = bib.updatedEntries[key];
+        myDocument.updateBibEntry(key, rendered);
+    }
+}
 ```
 
 Note, for some intuition, if you call `batchedUpdates()` again immediately, the 
 diff will be empty.
 
+### Bibliographies
+
+There are two functions for producing a bibliography.
+
+```javascript
+// returns BibliographyMeta
+let meta = driver.bibliographyMeta();
+
+// This is an array of BibEntry
+let bibliography = driver.makeBibliography();
+for (let entry of bibliography) {
+}
+```
 
 ### Preview citation clusters
 
@@ -358,20 +380,25 @@ let allNotes = myDocument.footnotes.map(fn => {
 // Re-hydrate the entire document
 driver.resetReferences(allReferences);
 driver.initClusters(allNotes.map(fn => fn.cluster));
-driver.setClusterOrder(allNotes.map(fn => { id: note.cluster.id, note: note.number }));
+driver.setClusterOrder(allNotes.map(fn => { id: fn.cluster.id, note: fn.number }));
 
-// Build every cluster, only after the driver knows about all of them
-allNotes.forEach(fn => {
-    fn.renderedHtml = driver.builtCluster(fn.cluster.id);
-});
+// Render every cluster and bibliography item.
+// It then drains the update queue, leaving the diff empty for the next edit.
+// see the FullRender typescript type
+let render = driver.fullRender();
 
-let bibliography = driver.makeBibliography();
+// Write out the rendered clusters into the doc
+for (let fn of allNotes) {
+    fn.renderedHtml = render.allClusters[fn.cluster.id];
+}
 
-// Drain the update queue, so the driver knows you're up to date and won't send 
-// you a whole-document diff
-driver.drain();
+// Write out the bibliography entries as well
+let allBibKeys = render.bib_entries.map(entry => entry.id);
+for (let bibEntry of render.bibEntries) {
+    myDocument.bibliographyMap[entry.id] = entry.value;
+}
 
 // Update the UI
-updateUserInterface(allNotes, bibliography);
+updateUserInterface(allNotes, myDocument, whatever);
 ```
 

--- a/crates/wasm/js-demo/js/App.tsx
+++ b/crates/wasm/js-demo/js/App.tsx
@@ -188,9 +188,11 @@ const Results = ({ driver, style }: { driver: Result<Driver, any>, style: string
             locales in use:
             <code>{JSON.stringify(d.toFetch().sort())}</code>
         </p>,
-        Err: e => <ErrorViewer style={style} error={e as StyleError} />
+        Err: e => <p style={{backgroundColor: '#ff00002b', marginBottom: '5px'}}>{e}</p>,
     });
 };
+
+
 
 const ErrorViewer = ({style, error}: { style: string, error: StyleError }) => {
     if (error.ParseError) {

--- a/crates/wasm/js-demo/js/App.tsx
+++ b/crates/wasm/js-demo/js/App.tsx
@@ -104,21 +104,18 @@ const initialClusters: Cluster[] = [
         cites: [
             { id: "citekey" }
         ],
-        note: 1,
     },
     {
         id: 2,
         cites: [
             { id: "citekey2" }
         ],
-        note: 2,
     },
     {
         id: 3,
         cites: [
             { id: "citekey", locator: "56" }
         ],
-        note: 3,
     },
 ];
 

--- a/crates/wasm/js-demo/js/Document.ts
+++ b/crates/wasm/js-demo/js/Document.ts
@@ -20,9 +20,11 @@ export class RenderedDocument {
     constructor(clusters: Cluster[], oci: Array<ClusterPosition>, driver: Driver) {
         this[immerable] = true;
         this.orderedClusterIds = oci;
-        for (let cluster of clusters) {
-            this.builtClusters[cluster.id] = driver.builtCluster(cluster.id);
-            // TODO: send note through a round trip and get it from builtCluster
+        let render = driver.fullRender();
+        this.builtClusters = render.allClusters;
+        for (let bibEntry of render.bibEntries) {
+            this.bibliographyIds.push(bibEntry.id);
+            this.bibliography[bibEntry.id] = bibEntry.value;
         }
     }
 
@@ -132,8 +134,6 @@ export class Document {
         driver.setClusterOrder(this.clusterPositions());
         driver.includeUncited(this.includeUncited);
         this.rendered = new RenderedDocument(this.clusters, this.clusterPositions(), driver);
-        // Drain the update queue, because we know we're up to date
-        this.driver.drain();
         console.log(this.driver);
     }
 

--- a/crates/wasm/js-demo/js/useDocument.ts
+++ b/crates/wasm/js-demo/js/useDocument.ts
@@ -62,7 +62,13 @@ export const useDocument = (initialStyle: string, initialReferences: Reference[]
     const updateStyle = async (style: string) => {
         if (driver.is_ok()) {
             let d = driver.unwrap();
-            setError(Option.from(d.setStyle(style)));
+            try {
+                d.setStyle(style);
+                setError(None());
+            } catch (e) {
+                console.error(e);
+                setError(Some("" + e));
+            }
             await flightFetcher(d);
             setDocument(document.map(doc => doc.selfUpdate()));
         } else {

--- a/crates/wasm/js-tests/package.json
+++ b/crates/wasm/js-tests/package.json
@@ -8,7 +8,7 @@
     "build": "wasm-pack build --target nodejs --out-dir pkg-node --scope citeproc-rs"
   },
   "dependencies": {
-    "@citeproc-rs/wasm": "file:../pkg-node",
+    "@citeproc-rs/wasm": "../pkg-node",
     "@types/jest": "^26.0.14"
   },
   "devDependencies": {

--- a/crates/wasm/js-tests/utils.ts
+++ b/crates/wasm/js-tests/utils.ts
@@ -1,0 +1,66 @@
+import { Driver, UpdateSummary } from "@citeproc-rs/wasm";
+
+export const mkStyle = (inner: string, bibliography?: string) => {
+    return `
+    <style class="note">
+      <citation>
+        <layout>
+          ${inner}
+        </layout>
+      </citation>
+      ${ bibliography != null ? bibliography : "" }
+    </style>
+    `;
+}
+
+export const mkLocale = (lang: string, terms: { [key: string]: string }) => {
+    return `
+    <?xml version="1.0" encoding="utf-8"?> <locale xml:lang="${lang}">
+    <terms>
+        ${ Object.entries(terms).map((k,v) => `<term name="${k}">${v}</term>`).join("\n") }
+    </terms>
+    </locale>
+    `;
+}
+
+export class Fetcher {
+    constructor(private callback: (lang: string) => void, private factory: (lang: string) => string) { }
+    async fetchLocale(lang: string) {
+        this.callback(lang);
+        return this.factory(lang);
+    }
+}
+
+export const boringFetcher = new Fetcher(
+    () => {},
+    (lang: string) => mkLocale(lang, {})
+);
+
+export const withDriver = (cfg: any, callback: (driver: Driver) => void) => {
+    let style = cfg.style || mkStyle('<text variable="title" />');
+    let fetcher = cfg.fetcher || boringFetcher;
+    let fmt = cfg.format || "plain";
+    let driver = Driver.new(style, fetcher, fmt);
+    callback(driver);
+    driver.free();
+};
+
+export const oneOneOne = (driver: Driver, r?: any) => {
+    let refr = {
+        type: "book",
+        title: "TEST_TITLE",
+        ...r,
+        id: "citekey"
+    }
+    driver.insertReference(refr);
+    driver.insertCluster({id: 1, cites: [{id: "citekey"}]});
+    driver.setClusterOrder([{ id: 1 }]);
+};
+
+export const checkUpdatesLen = (up: UpdateSummary, clusterCount: number, bibCount: number) => {
+    let updates = up;
+    expect(updates.clusters.length).toBe(clusterCount);
+    let updatedKeys = Object.keys(updates.bibliography?.updatedEntries || {});
+    expect(updatedKeys.length).toBe(bibCount);
+};
+

--- a/crates/wasm/js-tests/yarn.lock
+++ b/crates/wasm/js-tests/yarn.lock
@@ -871,7 +871,7 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@citeproc-rs/wasm@file:../pkg-node":
+"@citeproc-rs/wasm@../pkg-node":
   version "0.0.1"
 
 "@cnakazawa/watch@^1.0.3":

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -294,6 +294,8 @@ impl Driver {
     }
 
     /// Returns all the clusters and bibliography entries in the document.
+    /// Also drains the queue, just like batchedUpdates().
+    /// Use this to rehydrate a document or run non-interactively.
     #[wasm_bindgen(js_name = "fullRender")]
     pub fn full_render(&self) -> Result<TFullRender, JsValue> {
         let mut eng = self.engine.borrow_mut();
@@ -307,8 +309,7 @@ impl Driver {
         Ok(js_err!(JsValue::from_serde(&all).map(TFullRender::from)))
     }
 
-    /// Drains the `batchedUpdates` queue manually. Use it to avoid serializing an unneeded
-    /// `UpdateSummary`.
+    /// Drains the `batchedUpdates` queue manually.
     #[wasm_bindgen(js_name = "drain")]
     pub fn drain(&self) {
         let mut eng = self.engine.borrow_mut();


### PR DESCRIPTION
- Better typescript for the bibliography APIs
- Add fullRender() which handles draining queue and gives you every rendered 
  string in the document.
- Document wasm's bibliography features in the README
- Corrected documentation for batchedUpdates
- Improve and test the bibliography diffing returned from batchedUpdates