### PR TITLE
Don't exclude the no-modules target from NPM builds

### DIFF
--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -89,7 +89,7 @@ jobs:
         run: |
           ./scripts/npm-pkg-config.sh --package-only --canary-sha ${{steps.version.outputs.short_sha}}
           # log in to the NPM repository
-          echo "//registry.npmjs.org/:_authToken=${{secrets.NPM_PUBLISH_TOKEN}}" >> .npmrc
+          echo "//registry.npmjs.org/:_authToken=${{secrets.NPM_PUBLISH_TOKEN}}" > .npmrc
           npm publish dist --tag canary --access public
 
       - name: Publish to GitHub Packages canary dist tag
@@ -102,7 +102,7 @@ jobs:
             --github-packages @cormacrelf/citeproc-rs/citeproc-wasm \
             --set-name "@cormacrelf/citeproc-wasm"
           # log in to the NPM repository
-          echo "//npm.pkg.github.com/:_authToken=${{secrets.GITHUB_TOKEN}}" >> .npmrc
+          echo "//npm.pkg.github.com/:_authToken=${{secrets.GITHUB_TOKEN}}" > .npmrc
           npm publish dist --tag canary --access public
 
 

--- a/crates/citeproc/src/processor.rs
+++ b/crates/citeproc/src/processor.rs
@@ -146,13 +146,13 @@ impl Processor {
         let mut db = Processor::safe_default(fetcher);
         db.formatter = format.make_markup();
         let style = Arc::new(Style::from_str(style_string)?);
-        db.set_style_with_durability(style, Durability::MEDIUM);
+        db.set_style_with_durability(style, Durability::HIGH);
         Ok(db)
     }
 
     pub fn set_style_text(&mut self, style_text: &str) -> Result<(), StyleError> {
         let style = Style::from_str(style_text)?;
-        self.set_style_with_durability(Arc::new(style), Durability::MEDIUM);
+        self.set_style_with_durability(Arc::new(style), Durability::HIGH);
         Ok(())
     }
 
@@ -265,7 +265,7 @@ impl Processor {
     }
 
     pub fn clear_references(&mut self) {
-        self.set_all_keys(Arc::new(HashSet::new()));
+        self.set_all_keys_with_durability(Arc::new(HashSet::new()), Durability::MEDIUM);
     }
 
     fn intern_cluster_id(&self, string: impl AsRef<str>) -> ClusterId {
@@ -316,9 +316,9 @@ impl Processor {
     pub fn reset_references(&mut self, refs: Vec<Reference>) {
         let keys: HashSet<Atom> = refs.iter().map(|r| r.id.clone()).collect();
         for r in refs {
-            self.set_reference_input(r.id.clone(), Arc::new(r));
+            self.set_reference_input_with_durability(r.id.clone(), Arc::new(r), Durability::MEDIUM);
         }
-        self.set_all_keys(Arc::new(keys));
+        self.set_all_keys_with_durability(Arc::new(keys), Durability::MEDIUM);
     }
 
     pub fn extend_references(&mut self, refs: Vec<Reference>) {
@@ -326,24 +326,24 @@ impl Processor {
         let mut keys = HashSet::clone(&keys);
         for r in refs {
             keys.insert(r.id.clone());
-            self.set_reference_input(r.id.clone(), Arc::new(r));
+            self.set_reference_input_with_durability(r.id.clone(), Arc::new(r), Durability::MEDIUM);
         }
-        self.set_all_keys(Arc::new(keys));
+        self.set_all_keys_with_durability(Arc::new(keys), Durability::MEDIUM);
     }
 
     pub fn insert_reference(&mut self, refr: Reference) {
         let keys = self.all_keys();
         let mut keys = HashSet::clone(&keys);
         keys.insert(refr.id.clone());
-        self.set_reference_input(refr.id.clone(), Arc::new(refr));
-        self.set_all_keys(Arc::new(keys));
+        self.set_reference_input_with_durability(refr.id.clone(), Arc::new(refr), Durability::MEDIUM);
+        self.set_all_keys_with_durability(Arc::new(keys), Durability::MEDIUM);
     }
 
     pub fn remove_reference(&mut self, id: Atom) {
         let keys = self.all_keys();
         let mut keys = HashSet::clone(&keys);
         keys.remove(&id);
-        self.set_all_keys(Arc::new(keys));
+        self.set_all_keys_with_durability(Arc::new(keys), Durability::MEDIUM);
     }
 
     pub fn include_uncited(&mut self, uncited: IncludeUncited) {
@@ -354,7 +354,7 @@ impl Processor {
                 Uncited::Enumerated(list.iter().map(String::as_str).map(Atom::from).collect())
             }
         };
-        self.set_all_uncited(Arc::new(db_uncited));
+        self.set_all_uncited_with_durability(Arc::new(db_uncited), Durability::MEDIUM);
     }
 
     pub fn init_clusters(&mut self, clusters: Vec<Cluster<Markup>>) {
@@ -573,7 +573,7 @@ impl Processor {
         let mut langs = (*self.locale_input_langs()).clone();
         for (lang, xml) in locales {
             langs.insert(lang.clone());
-            self.set_locale_input_xml_with_durability(lang, Arc::new(xml), Durability::MEDIUM);
+            self.set_locale_input_xml_with_durability(lang, Arc::new(xml), Durability::HIGH);
         }
         self.set_locale_input_langs(Arc::new(langs));
     }

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -9,11 +9,12 @@ pub use cite::*;
 pub use xml::*;
 pub use cluster::*;
 
+use salsa::Durability;
+
 pub fn safe_default(db: &mut (impl cite::CiteDatabase + xml::LocaleDatabase + xml::StyleDatabase)) {
     use std::sync::Arc;
-    // TODO: more salsa::inputs
-    db.set_style(Default::default());
-    db.set_all_keys(Default::default());
+    db.set_style_with_durability(Default::default(), Durability::HIGH);
+    db.set_all_keys_with_durability(Default::default(), Durability::MEDIUM);
     db.set_all_uncited(Default::default());
     db.set_cluster_ids(Arc::new(Default::default()));
     db.set_locale_input_langs(Default::default());

--- a/crates/wasm/.cargo/config
+++ b/crates/wasm/.cargo/config
@@ -2,4 +2,4 @@
 opt-level = "z" # otherwise the wasm binaries are too big to load quickly
 
 [profile.release]
-debug = true
+debug = 1

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -19,14 +19,10 @@ description = "citeproc-rs, compiled to WebAssembly"
 # other native binary targets (cargo only lets you set it
 # on the workspace root)
 
-# [profile.release]
-# # Tell `rustc` to optimize for small code size.
-# opt-level = "s"
-# lto = true
-
 # https://github.com/rustwasm/wasm-pack/issues/886#issuecomment-667669802
 [package.metadata.wasm-pack.profile.release]
-wasm-opt = ["-O3", "--enable-mutable-globals"]
+wasm-opt = ["-O3", "--enable-mutable-globals", "-g"]
+# wasm-opt = false
 
 [lib]
 crate-type = ["cdylib", "rlib"]
@@ -77,4 +73,3 @@ features = ["release_max_level_warn"]
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.18"
-

--- a/crates/wasm/scripts/model-package.json
+++ b/crates/wasm/scripts/model-package.json
@@ -14,6 +14,7 @@
     "_cjs/*",
     "_esm/*",
     "_web/*",
+    "_no_modules/*",
     "README.md"
   ],
   "main": "_cjs/citeproc_rs_wasm.js",

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -61,7 +61,7 @@ impl Driver {
 
     /// Sets the style (which will also cause everything to be recomputed)
     #[wasm_bindgen(js_name = "setStyle")]
-    pub fn set_style(&mut self, style_text: &str) -> Result<(), JsValue> {
+    pub fn set_style(&self, style_text: &str) -> Result<(), JsValue> {
         let mut eng = self.engine.borrow_mut();
         js_err!(eng.set_style_text(style_text));
         Ok(())
@@ -70,7 +70,7 @@ impl Driver {
     /// Completely overwrites the references library.
     /// This **will** delete references that are not in the provided list.
     #[wasm_bindgen(js_name = "resetReferences")]
-    pub fn reset_references(&mut self, refs: Box<[JsValue]>) -> Result<(), JsValue> {
+    pub fn reset_references(&self, refs: Box<[JsValue]>) -> Result<(), JsValue> {
         let refs = utils::read_js_array(refs)?;
         let mut engine = self.engine.borrow_mut();
         engine.reset_references(refs);
@@ -80,7 +80,7 @@ impl Driver {
     /// Inserts or overwrites references as a batch operation.
     /// This **will not** delete references that are not in the provided list.
     #[wasm_bindgen(js_name = "insertReferences")]
-    pub fn insert_references(&mut self, refs: Box<[JsValue]>) -> Result<(), JsValue> {
+    pub fn insert_references(&self, refs: Box<[JsValue]>) -> Result<(), JsValue> {
         let refs = utils::read_js_array(refs)?;
         self.engine.borrow_mut().extend_references(refs);
         Ok(())
@@ -90,7 +90,7 @@ impl Driver {
     ///
     /// * `refr` is a Reference object.
     #[wasm_bindgen(js_name = "insertReference")]
-    pub fn insert_reference(&mut self, refr: TReference) -> Result<(), JsValue> {
+    pub fn insert_reference(&self, refr: TReference) -> Result<(), JsValue> {
         let refr = js_err!(refr.into_serde());
         // inserting & replacing are the same
         self.engine.borrow_mut().insert_reference(refr);
@@ -100,7 +100,7 @@ impl Driver {
     /// Removes a reference by id. If it is cited, any cites will be dangling. It will also
     /// disappear from the bibliography.
     #[wasm_bindgen(js_name = "removeReference")]
-    pub fn remove_reference(&mut self, id: &str) -> Result<(), JsValue> {
+    pub fn remove_reference(&self, id: &str) -> Result<(), JsValue> {
         let id = Atom::from(id);
         self.engine.borrow_mut().remove_reference(id);
         Ok(())
@@ -110,7 +110,7 @@ impl Driver {
     ///
     /// * `refr` is a
     #[wasm_bindgen(js_name = "includeUncited")]
-    pub fn include_uncited(&mut self, uncited: TIncludeUncited) -> Result<(), JsValue> {
+    pub fn include_uncited(&self, uncited: TIncludeUncited) -> Result<(), JsValue> {
         let uncited = js_err!(uncited.into_serde());
         self.engine.borrow_mut().include_uncited(uncited);
         Ok(())
@@ -140,7 +140,7 @@ impl Driver {
 
     /// Inserts or replaces a cluster with a matching `id`.
     #[wasm_bindgen(js_name = "insertCluster")]
-    pub fn insert_cluster(&mut self, cluster: JsValue) -> Result<(), JsValue> {
+    pub fn insert_cluster(&self, cluster: JsValue) -> Result<(), JsValue> {
         let cluster: string_id::Cluster<Markup> = js_err!(cluster.into_serde());
         let mut eng = self.engine.borrow_mut();
         eng.insert_cites_str(&cluster.id, &cluster.cites);
@@ -149,7 +149,7 @@ impl Driver {
 
     /// Removes a cluster with a matching `id`
     #[wasm_bindgen(js_name = "removeCluster")]
-    pub fn remove_cluster(&mut self, cluster_id: &str) -> Result<(), JsValue> {
+    pub fn remove_cluster(&self, cluster_id: &str) -> Result<(), JsValue> {
         let mut eng = self.engine.borrow_mut();
         eng.remove_cluster_str(cluster_id);
         Ok(())
@@ -159,7 +159,7 @@ impl Driver {
     ///
     /// * `clusters` is a Cluster[]
     #[wasm_bindgen(js_name = "initClusters")]
-    pub fn init_clusters(&mut self, clusters: Box<[JsValue]>) -> Result<(), JsValue> {
+    pub fn init_clusters(&self, clusters: Box<[JsValue]>) -> Result<(), JsValue> {
         let clusters: Vec<_> = utils::read_js_array(clusters)?;
         self.engine.borrow_mut().init_clusters_str(clusters);
         Ok(())
@@ -190,7 +190,7 @@ impl Driver {
     ///
     #[wasm_bindgen(js_name = "previewCitationCluster")]
     pub fn preview_citation_cluster(
-        &mut self,
+        &self,
         cites: Box<[JsValue]>,
         positions: Box<[JsValue]>,
         format: &str,
@@ -249,7 +249,7 @@ impl Driver {
     ///
     /// May error without having set_cluster_ids, but with some set_cluster_note_number-s executed.
     #[wasm_bindgen(js_name = "setClusterOrder")]
-    pub fn set_cluster_order(&mut self, positions: Box<[JsValue]>) -> Result<(), JsValue> {
+    pub fn set_cluster_order(&self, positions: Box<[JsValue]>) -> Result<(), JsValue> {
         let positions: Vec<string_id::ClusterPosition> = utils::read_js_array(positions)?;
         let mut eng = self.engine.borrow_mut();
         js_err!(eng.set_cluster_order_str(&positions));


### PR DESCRIPTION
The no-modules build wasn't listed in the package.json's `files` manifest, so it never got published. That was a bit of an oversight. Now you should be able to use it as described in the README.

It also includes some debug info in the published releases, so any stack traces from any panics that occur aren't nonsense, which previously I hadn't been able to get through wasm-opt.

- Preserve debug info through wasm-opt
- Remove `&mut self` from wasm Driver methods so it survives a panic
- Include _no_modules output to NPM package
- Set some better durabilities so salsa can optimize validation
