### PR TITLE
Use Rust 1.43 and fix wasm mutable globals

### DIFF
--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
-      - name: Install latest nightly
+      - name: Install Rust 1.43.1
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: 1.43.1
           override: true
       - name: Cache cargo directories
         uses: actions/cache@v2
@@ -52,10 +52,10 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
-      - name: Install latest nightly
+      - name: Install Rust 1.43.1
         uses: actions-rs/toolchain@v1
         with:
-            toolchain: nightly
+            toolchain: 1.43.1
             override: true
       - name: Cache cargo directories
         uses: actions/cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,10 +121,10 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
-      - name: Install latest nightly
+      - name: Install Rust 1.43.1
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: 1.43.1
           override: true
       - name: Cache cargo directories
         uses: actions/cache@v2

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ geared at:
 
 ## Supported Rust versions
 
-With a stable Rust compiler, 1.39 or later, you can:
+With a stable Rust compiler, 1.43 or later, you can:
 
 * Build `citeproc` as a library
 * Build a WebAssembly package (see below for details)

--- a/crates/proc/src/lib.rs
+++ b/crates/proc/src/lib.rs
@@ -4,8 +4,6 @@
 //
 // Copyright © 2018 Corporation for Digital Scholarship
 
-#![feature(rustc_attrs)]
-
 #[macro_use]
 extern crate log;
 

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -21,8 +21,8 @@ description = "citeproc-rs, compiled to WebAssembly"
 
 # https://github.com/rustwasm/wasm-pack/issues/886#issuecomment-667669802
 [package.metadata.wasm-pack.profile.release]
-wasm-opt = ["-O3", "--enable-mutable-globals", "-g"]
-# wasm-opt = false
+# wasm-opt = ["-O3", "--enable-mutable-globals", "-g"]
+wasm-opt = false
 
 [lib]
 crate-type = ["cdylib", "rlib"]


### PR DESCRIPTION
Fixes #84, disables wasm-opt so wasm builds are going to be a bit bigger.

MSRV is now 1.43 because of indextree's use of `i16::MIN` and a few other 
packages which are no longer supporting 1.39, I just haven't checked in a 
while. So there we are.
