### PR TITLE
Actually publish zotero files

### DIFF
--- a/crates/wasm/scripts/model-package.json
+++ b/crates/wasm/scripts/model-package.json
@@ -15,6 +15,7 @@
     "_esm/*",
     "_web/*",
     "_no_modules/*",
+    "_zotero/*",
     "README.md"
   ],
   "main": "_cjs/citeproc_rs_wasm.js",


### PR DESCRIPTION
As usual, I forgot to add the _zotero build to the npm package.json inclusion list.
